### PR TITLE
create PrivateKey and PublicKey classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php" : "~5.5|~7.0",
+        "php": "~5.5|~7.0",
         "ext-dom": "*",
         "ext-xml": "*",
         "ext-libxml": "*",
@@ -48,13 +48,22 @@
     },
     "autoload": {
         "psr-4": {
-          "NFePHP\\Common\\": "src/" 
-        } 
+            "NFePHP\\Common\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NFePHP\\Common\\Tests\\": "tests/"
+        }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "4.1-dev"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "scripts": {
+        "test": "phpunit -c phpunit.xml.dist",
+        "cs": "phpcs --standard=PSR2 src"
+    }
 }

--- a/src/Certificate/PrivateKey.php
+++ b/src/Certificate/PrivateKey.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace NFePHP\Common\Certificate;
+
+use NFePHP\Common\Exception\CertificateException;
+
+class PrivateKey implements SignatureInterface
+{
+    /**
+     * @var string
+     */
+    private $rawKey;
+
+    /**
+     * @var resource
+     */
+    private $resource;
+
+    /**
+     * PublicKey constructor.
+     * @param string $privateKey Content of private key file
+     */
+    public function __construct($privateKey)
+    {
+        $this->rawKey = $privateKey;
+        $this->read();
+    }
+
+    /**
+     * Get a private key
+     * @link http://php.net/manual/en/function.openssl-pkey-get-private.php
+     * @return void
+     * @throws CertificateException An error has occurred when get private key
+     */
+    protected function read()
+    {
+        if (!$resource = openssl_pkey_get_private($this->rawKey)) {
+            throw CertificateException::getPrivateKey();
+        }
+        $this->resource = $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sign($content, $algorithm = OPENSSL_ALGO_SHA1)
+    {
+        $encryptedData = '';
+        if (!openssl_sign($content, $encryptedData, $this->resource, $algorithm)) {
+            throw CertificateException::signContent();
+        }
+        return $encryptedData;
+    }
+
+    public function __toString()
+    {
+        return $this->rawKey;
+    }
+}

--- a/src/Certificate/PublicKey.php
+++ b/src/Certificate/PublicKey.php
@@ -81,7 +81,7 @@ class PublicKey implements VerificationInterface
      */
     public function isExpired()
     {
-        return new \DateTime('now') <= $this->validTo;
+        return new \DateTime('now') > $this->validTo;
     }
 
     public function __toString()

--- a/src/Certificate/PublicKey.php
+++ b/src/Certificate/PublicKey.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace NFePHP\Common\Certificate;
+
+use NFePHP\Common\Exception\CertificateException;
+
+class PublicKey implements VerificationInterface
+{
+    /**
+     * @var string
+     */
+    private $rawKey;
+
+    /**
+     * @var string
+     */
+    public $commonName;
+
+    /**
+     * @var \DateTime
+     */
+    public $validFrom;
+
+    /**
+     * @var \DateTime
+     */
+    public $validTo;
+
+    /**
+     * PublicKey constructor.
+     * @param string $publicKey
+     */
+    public function __construct($publicKey)
+    {
+        $this->rawKey = $publicKey;
+        $this->read();
+    }
+
+    /**
+     * Parse an X509 certificate and define the information in object
+     * @link http://php.net/manual/en/function.openssl-x509-read.php
+     * @link http://php.net/manual/en/function.openssl-x509-parse.php
+     * @return void
+     * @throws CertificateException Unable to open certificate
+     */
+    protected function read()
+    {
+        if (!$resource = openssl_x509_read($this->rawKey)) {
+            throw CertificateException::unableToOpen();
+        }
+
+        $detail = openssl_x509_parse($resource, false);
+        $this->commonName = $detail['subject']['commonName'];
+        $this->validFrom = \DateTime::createFromFormat('ymdHis\Z', $detail['validFrom']);
+        $this->validTo = \DateTime::createFromFormat('ymdHis\Z', $detail['validTo']);
+    }
+
+    /**
+     * Verify signature
+     * @link http://php.net/manual/en/function.openssl-verify.php
+     * @param string $data
+     * @param string $signature
+     * @param int $algorithm [optional] For more information see the list of Signature Algorithms.
+     * @return int Returns true if the signature is correct, false if it is incorrect
+     * @throws CertificateException An error has occurred when verify signature
+     */
+    public function verify($data, $signature, $algorithm = OPENSSL_ALGO_SHA1)
+    {
+        $verified = openssl_verify($data, $signature, $this->rawKey, $algorithm);
+
+        if ($verified === static::SIGNATURE_ERROR) {
+            throw CertificateException::signatureFailed();
+        }
+
+        return $verified === static::SIGNATURE_CORRECT;
+    }
+
+    /**
+     * Check if is in valid date interval.
+     * @return bool Returns true
+     */
+    public function isExpired()
+    {
+        return new \DateTime('now') <= $this->validTo;
+    }
+
+    public function __toString()
+    {
+        return $this->rawKey;
+    }
+}

--- a/src/Certificate/SignatureInterface.php
+++ b/src/Certificate/SignatureInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NFePHP\Common\Certificate;
+
+use NFePHP\Common\Exception\CertificateException;
+
+interface SignatureInterface
+{
+    /**
+     * Generate signature.
+     * @link http://php.net/manual/en/function.openssl-sign.php
+     * @param string $content
+     * @param int $algorithm
+     * @return string Returns the signature data.
+     * @throws CertificateException
+     */
+    public function sign($content, $algorithm = OPENSSL_ALGO_SHA1);
+}

--- a/src/Certificate/VerificationInterface.php
+++ b/src/Certificate/VerificationInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NFePHP\Common\Certificate;
+
+use NFePHP\Common\Exception\CertificateException;
+
+interface VerificationInterface
+{
+    const SIGNATURE_CORRECT = 1;
+
+    const SIGNATURE_INCORRECT = 0;
+
+    const SIGNATURE_ERROR = -1;
+
+    /**
+     * Verify signature
+     * @link http://php.net/manual/en/function.openssl-verify.php
+     * @param string $data
+     * @param string $signature
+     * @param int $algorithm [optional] For more information see the list of Signature Algorithms.
+     * @return int Returns true if the signature is correct, false if it is incorrect
+     * @throws CertificateException An error has occurred when verify signature
+     */
+    public function verify($data, $signature, $algorithm = OPENSSL_ALGO_SHA1);
+}

--- a/src/Exception/CertificateException.php
+++ b/src/Exception/CertificateException.php
@@ -14,29 +14,36 @@ class CertificateException extends \RuntimeException implements ExceptionInterfa
 {
     public static function unableToRead()
     {
-        return new static('Unable to read certificate, get follow error: ' . static::getOpenSSLError());
+        return new static('Unable to read certificate, ' . static::getOpenSSLError());
     }
 
     public static function unableToOpen()
     {
-        return new static('Unable to open certificate, get follow error: ' . static::getOpenSSLError());
+        return new static('Unable to open certificate, ' . static::getOpenSSLError());
     }
 
     public static function signContent()
     {
         return new static(
-            'An unexpected error has occurred when sign a content, get follow error: ' . static::getOpenSSLError()
+            'An unexpected error has occurred when sign a content, ' . static::getOpenSSLError()
         );
     }
 
     public static function getPrivateKey()
     {
-        return new static('An error has occurred when get private key, get follow error: ' . static::getOpenSSLError());
+        return new static('An error has occurred when get private key, ' . static::getOpenSSLError());
+    }
+
+    public static function signatureFailed()
+    {
+        return new static(
+            'An error has occurred when verify signature, ' . static::getOpenSSLError()
+        );
     }
 
     private static function getOpenSSLError()
     {
-        $error = '';
+        $error = 'get follow error: ';
         while ($msg = openssl_error_string()) {
             $error .= "($msg)";
         }

--- a/tests/Certificate/CertificateTest.php
+++ b/tests/Certificate/CertificateTest.php
@@ -3,6 +3,7 @@
 namespace NFePHP\Common\Tests\Certificate;
 
 use NFePHP\Common\Certificate;
+use NFePHP\Common\Exception\CertificateException;
 
 class CertificateTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,10 +13,17 @@ class CertificateTest extends \PHPUnit_Framework_TestCase
     {
         $certificate = new Certificate(file_get_contents(__DIR__ . self::TEST_CERTIFICATE_FILE), 'associacao');
         $this->assertInstanceOf(Certificate::class, $certificate);
-        $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->companyName);
-        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->validFrom);
-        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->validTo);
+        $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->getValidTo());
         $this->assertFalse($certificate->isExpired());
-        $this->assertNotEmpty($certificate->sign('nfe'));
+        $dataSigned = $certificate->sign('nfe');
+        $this->assertTrue($certificate->verify('nfe', $dataSigned));
+    }
+
+    public function testShouldGetExceptionWhenLoadPfxCertificate()
+    {
+        $this->setExpectedException(CertificateException::class);
+        new Certificate(file_get_contents(__DIR__ . self::TEST_CERTIFICATE_FILE), 'error');
     }
 }

--- a/tests/Certificate/CertificateTest.php
+++ b/tests/Certificate/CertificateTest.php
@@ -16,7 +16,7 @@ class CertificateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
         $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
         $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->getValidTo());
-        $this->assertFalse($certificate->isExpired());
+        $this->assertTrue($certificate->isExpired());
         $dataSigned = $certificate->sign('nfe');
         $this->assertTrue($certificate->verify('nfe', $dataSigned));
     }

--- a/tests/Certificate/PrivateKeyTest.php
+++ b/tests/Certificate/PrivateKeyTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NFePHP\Common\Tests\Certificate;
+
+use NFePHP\Common\Certificate\PrivateKey;
+use NFePHP\Common\Certificate\SignatureInterface;
+
+class PrivateKeyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldInstantiate()
+    {
+        $key = new PrivateKey(file_get_contents(__DIR__ . '/../fixtures/certs/x99999090910270_priKEY.pem'));
+        $this->assertInstanceOf(SignatureInterface::class, $key);
+        $this->assertNotNull($key->sign('nfe'));
+    }
+}

--- a/tests/Certificate/PublicKeyTest.php
+++ b/tests/Certificate/PublicKeyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace NFePHP\Common\Tests\Certificate;
+
+use NFePHP\Common\Certificate\PublicKey;
+use NFePHP\Common\Certificate\VerificationInterface;
+
+class PublicKeyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldInstantiate()
+    {
+        $key = new PublicKey(file_get_contents(__DIR__ . '/../fixtures/certs/x99999090910270_pubKEY.pem'));
+        $this->assertInstanceOf(VerificationInterface::class, $key);
+        $this->assertEquals('NFe - Associacao NF-e:99999090910270', $key->commonName);
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $key->validFrom);
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $key->validTo);
+        $this->assertFalse($key->isExpired());
+    }
+}

--- a/tests/Certificate/PublicKeyTest.php
+++ b/tests/Certificate/PublicKeyTest.php
@@ -14,6 +14,6 @@ class PublicKeyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $key->commonName);
         $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $key->validFrom);
         $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $key->validTo);
-        $this->assertFalse($key->isExpired());
+        $this->assertTrue($key->isExpired());
     }
 }


### PR DESCRIPTION
agora cada classe tem a sua responsabilidade totalmente isolada permite que possamos usar chave privada ou pública de forma totalmente isolada.

Isso pode facilitar quando não existir o PFX para extraí-las.

baseado nas alterações do @Ferreiramg #47 