### PR TITLE
add readPfx method to able flexibility

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -20,19 +20,19 @@ class Certificate implements SignatureInterface, VerificationInterface
      */
     public $publicKey;
 
-    public function __construct($content, $password = '')
+    public function __construct(PrivateKey $privateKey, PublicKey $publicKey)
     {
-        $this->read($content, $password);
+        $this->privateKey = $privateKey;
+        $this->publicKey = $publicKey;
     }
 
-    private function read($content, $password)
+    public static function readPfx($content, $password)
     {
         $certs = [];
         if (!openssl_pkcs12_read($content, $certs, $password)) {
             throw CertificateException::unableToRead();
         }
-        $this->privateKey = new PrivateKey($certs['pkey']);
-        $this->publicKey = new PublicKey($certs['cert']);
+        return new static(new PrivateKey($certs['pkey']), new PublicKey($certs['cert']));
     }
 
     /**

--- a/tests/Certificate/CertificateTest.php
+++ b/tests/Certificate/CertificateTest.php
@@ -7,11 +7,29 @@ use NFePHP\Common\Exception\CertificateException;
 
 class CertificateTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_CERTIFICATE_FILE = '/../fixtures/certs/certificado_teste.pfx';
+    const TEST_PFX_FILE = '/../fixtures/certs/certificado_teste.pfx';
+
+    const TEST_PRIVATE_KEY = '/../fixtures/certs/x99999090910270_priKEY.pem';
+
+    const TEST_PUBLIC_KEY = '/../fixtures/certs/x99999090910270_pubKEY.pem';
 
     public function testShouldLoadPfxCertificate()
     {
-        $certificate = new Certificate(file_get_contents(__DIR__ . self::TEST_CERTIFICATE_FILE), 'associacao');
+        $certificate = Certificate::readPfx(file_get_contents(__DIR__ . self::TEST_PFX_FILE), 'associacao');
+        $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->getValidTo());
+        $this->assertTrue($certificate->isExpired());
+        $dataSigned = $certificate->sign('nfe');
+        $this->assertTrue($certificate->verify('nfe', $dataSigned));
+    }
+
+    public function testShouldLoadCertificate()
+    {
+        $certificate = new Certificate(
+            new Certificate\PrivateKey(file_get_contents(__DIR__ . self::TEST_PRIVATE_KEY)),
+            new Certificate\PublicKey(file_get_contents(__DIR__ . self::TEST_PUBLIC_KEY))
+        );
         $this->assertInstanceOf(Certificate::class, $certificate);
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
         $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
@@ -24,6 +42,6 @@ class CertificateTest extends \PHPUnit_Framework_TestCase
     public function testShouldGetExceptionWhenLoadPfxCertificate()
     {
         $this->setExpectedException(CertificateException::class);
-        new Certificate(file_get_contents(__DIR__ . self::TEST_CERTIFICATE_FILE), 'error');
+        Certificate::readPfx(file_get_contents(__DIR__ . self::TEST_PFX_FILE), 'error');
     }
 }


### PR DESCRIPTION
on fire 🔥 

com base no [comentário](https://github.com/nfephp-org/sped-common/pull/49#issuecomment-241198400) do @robmachado percebi que ter um método para ler o PFX faria muito mais sentido do que deixá-lo no contrutor