### PR TITLE
[UPD] Ajuste na Classe Dom

### DIFF
--- a/src/Dom/Dom.php
+++ b/src/Dom/Dom.php
@@ -129,6 +129,7 @@ class Dom extends DOMDocument
      */
     public function addChild(&$parent, $name, $content = '', $obrigatorio = false, $descricao = "", $force = false)
     {
+        $content = trim($content);
         if ($obrigatorio && $content === '' && !$force) {
             $this->erros[] = array(
                 "tag" => $name,
@@ -136,8 +137,7 @@ class Dom extends DOMDocument
                 "erro" => "Preenchimento Obrigatório!"
             );
         }
-        if ($obrigatorio || $content !== '') {
-            $content = trim($content);
+        if ($obrigatorio || $content !== '' || $force) {
             $content = htmlspecialchars($content, ENT_QUOTES);
             $temp = $this->createElement($name, $content);
             $parent->appendChild($temp);


### PR DESCRIPTION
 para remover espaços em  branco do parâmetro "content" antes da avaliação e construção da TAG, para evitar a inserção de TAG por passagem incorreta de dados