### PR TITLE
Limpar espaços do conteúdo ao adicionar uma tag

### DIFF
--- a/src/Base/BaseTools.php
+++ b/src/Base/BaseTools.php
@@ -470,9 +470,16 @@ class BaseTools
         $this->urlService = $aURL[$service]['URL'];
         //recuperação do método
         $this->urlMethod = $aURL[$service]['method'];
+
         //montagem do namespace do serviço
-        $this->urlOperation = $aURL[$service]['operation'];
-        $this->urlNamespace = sprintf("%s/wsdl/%s", $this->urlPortal, $this->urlOperation);
+        if ($tipo == "cte") {
+            $this->urlNamespace = sprintf("%s/wsdl/%s", $this->urlPortal, $service);
+
+        } else {
+            $this->urlOperation = $aURL[$service]['operation'];
+            $this->urlNamespace = sprintf("%s/wsdl/%s", $this->urlPortal, $this->urlOperation);
+        }
+
         //montagem do cabeçalho da comunicação SOAP
         $this->urlHeader = $this->zMountHeader($tipo, $this->urlNamespace, $this->urlcUF, $this->urlVersion);
         return true;

--- a/src/Dom/Dom.php
+++ b/src/Dom/Dom.php
@@ -129,14 +129,14 @@ class Dom extends DOMDocument
      */
     public function addChild(&$parent, $name, $content = '', $obrigatorio = false, $descricao = "", $force = false)
     {
-        if ($obrigatorio && $content === '' && !$force) {
+        if ($obrigatorio && trim($content) === '' && !$force) {
             $this->erros[] = array(
                 "tag" => $name,
                 "desc" => $descricao,
                 "erro" => "Preenchimento Obrigatório!"
             );
         }
-        if ($obrigatorio || $content !== '') {
+        if ($obrigatorio || trim($content) !== '') {
             $content = trim($content);
             $content = htmlspecialchars($content, ENT_QUOTES);
             $temp = $this->createElement($name, $content);


### PR DESCRIPTION

Adicionado na função abaixo na hora de testar se tem algum conteúdo na varoavél a função trim para eliminar espaços em branco. 

Senti essa necessidade pois as vezes setamos para a tag um conteúdo de um campo que mesmo estando vazio ele fica um espaço em branco fazendo com que na geração do xml inclua a tag mesmo sem informação.

public function addChild(&$parent, $name, $content = '', $obrigatorio = false, $descricao = "", $force = false)
    {
        if ($obrigatorio && **trim**($content) === '' && !$force) {
            $this->erros[] = array(
                "tag" => $name,
                "desc" => $descricao,
                "erro" => "Preenchimento Obrigatório!"
            );
        }
        if ($obrigatorio || **trim**($content) !== '') {
            $content = trim($content);
            $content = htmlspecialchars($content, ENT_QUOTES);
            $temp = $this->createElement($name, $content);
            $parent->appendChild($temp);
        }
    }