### PR TITLE
Junção de chave privada e pública em um arquivo apenas

### DIFF
--- a/src/Soap/SoapBase.php
+++ b/src/Soap/SoapBase.php
@@ -155,6 +155,7 @@ abstract class SoapBase implements SoapInterface
         $this->logger = $logger;
         $this->certificate = $this->checkCertValidity($certificate);
         $this->setTemporaryFolder(sys_get_temp_dir() . '/sped/');
+        $this->saveTemporarilyKeyFiles();
     }
     
     /**
@@ -395,7 +396,7 @@ abstract class SoapBase implements SoapInterface
         );
         $ret &= $this->filesystem->put(
             $this->certfile,
-            "{$this->certificate}"
+            $this->certificate->privateKey.$this->certificate->publicKey
         );
         if (!$ret) {
             throw new RuntimeException(


### PR DESCRIPTION
Acredito ter encontrado estes dois problemas na classe são duas alterações, 

- A primeira no construtor, onde adicionei a função que salva o certificado na pasta temporária.

- A segunda parte de que, o certificado, pelo menos no meu caso precisava ser um arquivo composto da publickey e da privatekey no mesmo arquivom sendo assim uni as duas através de uma simplesconcatenação, e no meu caso deu certo