### PR TITLE
[fix][certificationChain->getExtraCertsForPFX] condicao ao contrario

### DIFF
--- a/src/Certificate/CertificationChain.php
+++ b/src/Certificate/CertificationChain.php
@@ -112,7 +112,7 @@ CONTENT;
         foreach ($list as $cert) {
             $ec[] = "{$cert}";
         }
-        if (empty($ec)) {
+        if (!empty($ec)) {
             $args = ['extracerts' => $ec];
         }
         return $args;


### PR DESCRIPTION
a função getExtraCertsForPFX estava sempre retornando array vazio por causa da condição.