### PR TITLE
[UPD] bug no metodo mountSoapHeaders com erros nos xmls

### DIFF
--- a/src/Soap/SoapBase.php
+++ b/src/Soap/SoapBase.php
@@ -414,13 +414,13 @@ abstract class SoapBase implements SoapInterface
         }
         $headerItems = '';
         foreach ($header->data as $key => $value) {
-            $headerItems = '<'.$key.'>'.$value.'<'.$key.'>';
+            $headerItems .= '<'.$key.'>'.$value.'</'.$key.'>';
         }
         return sprintf(
             '<%s:Header><%s xmlns="%s">%s</%s></%s:Header>',
             $envelopPrefix,
             $header->name,
-            $header->ns === null ? '' : $header->ns,
+            $header->namespace === null ? '' : $header->namespace,
             $headerItems,
             $header->name,
             $envelopPrefix


### PR DESCRIPTION
O método tinha quebrado a emissão de nfe, sobrescrevia do data do header deixando somente o ultimo e abria 2x a tag de vez de abrir e fechar. $header->ns não existe alterando para $header->namespace

