### PR TITLE
WIP: Limpeza e melhoria do método de assinatura

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -202,7 +202,7 @@ class Signer
      * @param string $content
      * @return string
      */
-    public static function removeSignature(string $content)
+    public static function removeSignature($content)
     {
         if (!self::existsSignature($content)) {
             return $content;
@@ -231,7 +231,7 @@ class Signer
      * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(string $content, $tagname = '', $canonical = self::CANONICAL)
+    public static function isSigned($content, $tagname = '', $canonical = self::CANONICAL)
     {
         if (!self::existsSignature($content)) {
             return false;
@@ -249,7 +249,7 @@ class Signer
      * @param string $content
      * @return boolean
      */
-    public static function existsSignature(string $content)
+    public static function existsSignature($content)
     {
         if (!Validator::isXML($content)) {
             throw SignerException::isNotXml();
@@ -270,7 +270,7 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    private static function signatureCheck(string $xml, $canonical = self::CANONICAL)
+    private static function signatureCheck($xml, $canonical = self::CANONICAL)
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -311,7 +311,7 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck(string $xml, $tagname = '', $canonical = self::CANONICAL)
+    private static function digestCheck($xml, $tagname = '', $canonical = self::CANONICAL)
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -381,7 +381,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL)
+    private static function makeDigest(DOMNode $node, $algorithm, $canonical = self::CANONICAL)
     {
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -56,7 +56,7 @@ class Signer
         $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument {
+    ) {
         $signed = $doc;
 
         foreach ($tags as $tagName) {
@@ -100,7 +100,7 @@ class Signer
         $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument {
+    ) {
         if (!empty($canonical)) {
             self::$canonical = $canonical;
         }
@@ -134,7 +134,7 @@ class Signer
         string $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument {
+    ) {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
         $nsSignatureMethod = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
@@ -202,7 +202,7 @@ class Signer
      * @param string $content
      * @return string
      */
-    public static function removeSignature(string $content): string
+    public static function removeSignature(string $content)
     {
         if (!self::existsSignature($content)) {
             return $content;
@@ -231,7 +231,7 @@ class Signer
      * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(string $content, $tagname = '', $canonical = self::CANONICAL): bool
+    public static function isSigned(string $content, $tagname = '', $canonical = self::CANONICAL)
     {
         if (!self::existsSignature($content)) {
             return false;
@@ -249,7 +249,7 @@ class Signer
      * @param string $content
      * @return boolean
      */
-    public static function existsSignature(string $content): bool
+    public static function existsSignature(string $content)
     {
         if (!Validator::isXML($content)) {
             throw SignerException::isNotXml();
@@ -270,7 +270,7 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    private static function signatureCheck(string $xml, $canonical = self::CANONICAL): bool
+    private static function signatureCheck(string $xml, $canonical = self::CANONICAL)
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -311,7 +311,7 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck(string $xml, $tagname = '', $canonical = self::CANONICAL): bool
+    private static function digestCheck(string $xml, $tagname = '', $canonical = self::CANONICAL)
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -381,7 +381,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL): string
+    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL)
     {
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);
@@ -395,7 +395,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function canonize(DOMNode $node, $canonical = self::CANONICAL): string
+    private static function canonize(DOMNode $node, $canonical = self::CANONICAL)
     {
         return $node->C14N(
             $canonical[0],

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -53,8 +53,8 @@ class Signer
         Certificate $certificate,
         DOMDocument $doc,
         array $tags,
-        string $mark = 'Id',
-        int $algorithm = OPENSSL_ALGO_SHA1,
+        $mark = 'Id',
+        $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
     ): DOMDocument {
         $signed = $doc;
@@ -97,8 +97,8 @@ class Signer
         Certificate $certificate,
         DOMDocument $content,
         DOMNode $tagNode,
-        string $mark = 'Id',
-        int $algorithm = OPENSSL_ALGO_SHA1,
+        $mark = 'Id',
+        $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
     ): DOMDocument {
         if (!empty($canonical)) {
@@ -131,8 +131,8 @@ class Signer
         Certificate $certificate,
         DOMDocument $dom,
         DOMElement $node,
-        string $mark,
-        int $algorithm = OPENSSL_ALGO_SHA1,
+        string $mark = 'Id',
+        $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
     ): DOMDocument {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
@@ -231,7 +231,7 @@ class Signer
      * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(string $content, string $tagname = '', $canonical = self::CANONICAL): bool
+    public static function isSigned(string $content, $tagname = '', $canonical = self::CANONICAL): bool
     {
         if (!self::existsSignature($content)) {
             return false;
@@ -311,7 +311,7 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck(string $xml, string $tagname = '', $canonical = self::CANONICAL): bool
+    private static function digestCheck(string $xml, $tagname = '', $canonical = self::CANONICAL): bool
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -109,7 +109,6 @@ class Signer
     private static function createSignature(
         Certificate $certificate,
         DOMDocument $dom,
-        DOMNode $root,
         DOMElement $node,
         string $mark,
         $algorithm = OPENSSL_ALGO_SHA1,
@@ -128,9 +127,9 @@ class Signer
         $nsTransformMethod1 ='http://www.w3.org/2000/09/xmldsig#enveloped-signature';
         $nsTransformMethod2 = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
         $idSigned = trim($node->getAttribute($mark));
-        $digestValue = self::makeDigest($node, $digestAlgorithm, $canonical);
         $signatureNode = $dom->createElementNS($nsDSIG, 'Signature');
-        $root->appendChild($signatureNode);
+        $signatureNode->setAttribute('Id', "Ass_$idSigned");
+        $node->parentNode->appendChild($signatureNode);
         $signedInfoNode = $dom->createElement('SignedInfo');
         $signatureNode->appendChild($signedInfoNode);
         $canonicalNode = $dom->createElement('CanonicalizationMethod');
@@ -141,11 +140,11 @@ class Signer
         $signatureMethodNode->setAttribute('Algorithm', $nsSignatureMethod);
         $referenceNode = $dom->createElement('Reference');
         $signedInfoNode->appendChild($referenceNode);
-
+        
         if (!empty($idSigned)) {
             $idSigned = "#$idSigned";
         }
-
+        
         $referenceNode->setAttribute('URI', $idSigned);
         $transformsNode = $dom->createElement('Transforms');
         $referenceNode->appendChild($transformsNode);
@@ -158,6 +157,7 @@ class Signer
         $digestMethodNode = $dom->createElement('DigestMethod');
         $referenceNode->appendChild($digestMethodNode);
         $digestMethodNode->setAttribute('Algorithm', $nsDigestMethod);
+        $digestValue = self::makeDigest($node, $digestAlgorithm, $canonical);
         $digestValueNode = $dom->createElement('DigestValue', $digestValue);
         $referenceNode->appendChild($digestValueNode);
         $c14n = self::canonize($signedInfoNode, $canonical);

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -52,8 +52,8 @@ class Signer
         string $content,
         string $tagname,
         string $mark = 'Id',
-        int $algorithm = OPENSSL_ALGO_SHA1,
-        array $canonical = self::CANONICAL,
+        $algorithm = OPENSSL_ALGO_SHA1,
+        $canonical = self::CANONICAL,
         string $rootname = ''
     ): string {
         if (empty($content))
@@ -112,8 +112,8 @@ class Signer
         DOMNode $root,
         DOMElement $node,
         string $mark,
-        int $algorithm = OPENSSL_ALGO_SHA1,
-        array $canonical = self::CANONICAL
+        $algorithm = OPENSSL_ALGO_SHA1,
+        $canonical = self::CANONICAL
     ): DOMDocument {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
@@ -208,7 +208,7 @@ class Signer
      * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(string $content, string $tagname = '', array $canonical = self::CANONICAL): bool {
+    public static function isSigned(string $content, string $tagname = '', $canonical = self::CANONICAL): bool {
         if (!self::existsSignature($content))
             return false;
 
@@ -242,7 +242,7 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    private static function signatureCheck(string $xml, array $canonical = self::CANONICAL): bool {
+    private static function signatureCheck(string $xml, $canonical = self::CANONICAL): bool {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -281,7 +281,7 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck(string $xml, string $tagname = '', array $canonical = self::CANONICAL): bool {
+    private static function digestCheck(string $xml, string $tagname = '', $canonical = self::CANONICAL): bool {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -334,7 +334,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(DOMNode $node, string $algorithm, array $canonical = self::CANONICAL): string {
+    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL): string {
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);
 
@@ -347,7 +347,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function canonize(DOMNode $node, array $canonical = self::CANONICAL): string {
+    private static function canonize(DOMNode $node, $canonical = self::CANONICAL): string {
         return $node->C14N(
             $canonical[0],
             $canonical[1],

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -32,7 +32,7 @@ use DOMElement;
 
 class Signer
 {
-    const CANONICAL = [true,false,null,null];
+    const CANONICAL = array(true,false,null,null);
     private static $canonical = self::CANONICAL;
     
     /**
@@ -49,13 +49,13 @@ class Signer
      */
     public static function sign(
         Certificate $certificate,
-        $content,
-        $tagname,
-        $mark = 'Id',
-        $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = self::CANONICAL,
-        $rootname = ''
-    ) {
+        string $content,
+        string $tagname,
+        string $mark = 'Id',
+        int $algorithm = OPENSSL_ALGO_SHA1,
+        array $canonical = self::CANONICAL,
+        string $rootname = ''
+    ): string {
         if (empty($content))
             throw SignerException::isNotXml();
         
@@ -111,10 +111,10 @@ class Signer
         DOMDocument $dom,
         DOMNode $root,
         DOMElement $node,
-        $mark,
-        $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = self::CANONICAL
-    ) {
+        string $mark,
+        int $algorithm = OPENSSL_ALGO_SHA1,
+        array $canonical = self::CANONICAL
+    ): DOMDocument {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
         $nsSignatureMethod = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
@@ -181,7 +181,7 @@ class Signer
      * @param string $content
      * @return string
      */
-    public static function removeSignature($content) {
+    public static function removeSignature(string $content): string {
         if (!self::existsSignature($content))
             return $content;
 
@@ -205,10 +205,10 @@ class Signer
      * @param string $content
      * @param string $tagname tag for sign (opcional)
      * @param array $canonical parameters to format node for signature (opcional)
-     * @return boolean
+     * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned($content, $tagname = '', $canonical = self::CANONICAL) {
+    public static function isSigned(string $content, string $tagname = '', array $canonical = self::CANONICAL): bool {
         if (!self::existsSignature($content))
             return false;
 
@@ -223,7 +223,7 @@ class Signer
      * @param string $content
      * @return boolean
      */
-    public static function existsSignature($content) {
+    public static function existsSignature(string $content): bool {
         if (!Validator::isXML($content))
             throw SignerException::isNotXml();
 
@@ -242,7 +242,7 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    private static function signatureCheck($xml, $canonical = self::CANONICAL) {
+    private static function signatureCheck(string $xml, array $canonical = self::CANONICAL): bool {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -281,7 +281,7 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck($xml, $tagname = '', $canonical = self::CANONICAL) {
+    private static function digestCheck(string $xml, string $tagname = '', array $canonical = self::CANONICAL): bool {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -334,10 +334,10 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(DOMNode $node, $algorithm, $canonical = self::CANONICAL) {
+    private static function makeDigest(DOMNode $node, string $algorithm, array $canonical = self::CANONICAL): string {
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);
-        
+
         return base64_encode($hashValue);
     }
     
@@ -347,7 +347,7 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function canonize(DOMNode $node, $canonical = self::CANONICAL) {
+    private static function canonize(DOMNode $node, array $canonical = self::CANONICAL): string {
         return $node->C14N(
             $canonical[0],
             $canonical[1],

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -37,16 +37,16 @@ class Signer
 
     /**
      * Make Signature for multiple tags within the document.
-     * 
+     *
      * @param Certificate $certificate
      * @param \DOMDocument $doc The XML to sign.
      * @param array $tags the tags to include signature.
      * @param string $mark for URI (optional).
      * @param int $algorithm (optional).
      * @param array $canonical parameters to format node for signature (optional).
-     * 
+     *
      * @return \DOMDocument
-     * 
+     *
      * @throws SignerException
      */
     public static function signMultipleTags(
@@ -56,7 +56,8 @@ class Signer
         string $mark = 'Id',
         int $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument {
+    ): DOMDocument
+    {
         $signed = $doc;
 
         foreach ($tags as $tagName) {
@@ -71,8 +72,9 @@ class Signer
                 $canonical
             );
 
-            if (!Signer::isSigned($signed->saveXML(), $tagName))
+            if (!Signer::isSigned($signed->saveXML(), $tagName)) {
                 throw SignerException::signatureComparisonFailed();
+            }
         }
 
         return $signed;
@@ -80,16 +82,16 @@ class Signer
     
     /**
      * Make the Signature tag.
-     * 
+     *
      * @param Certificate $certificate
      * @param \DOMDocument $content xml to sign
      * @param \DOMNode $tagNode The tagNode to be signed
      * @param string $mark for URI (optional)
      * @param int $algorithm (optional)
      * @param array $canonical parameters to format node for signature (optional)
-     * 
+     *
      * @return \DOMDocument
-     * 
+     *
      * @throws SignerException
      */
     public static function sign(
@@ -99,9 +101,11 @@ class Signer
         string $mark = 'Id',
         int $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument {
-        if (!empty($canonical))
+    ): DOMDocument
+    {
+        if (!empty($canonical)) {
             self::$canonical = $canonical;
+        }
         
         return self::createSignature(
             $certificate,
@@ -115,14 +119,14 @@ class Signer
     
     /**
      * Method that provides the signature of xml as standard SEFAZ.
-     * 
+     *
      * @param Certificate $certificate
      * @param \DOMDocument $dom The original document
      * @param \DOMElement $node node to be signed
      * @param string $mark Marker signed attribute
      * @param int $algorithm cryptographic algorithm (optional)
      * @param array $canonical parameters to format node for signature (optional)
-     * 
+     *
      * @return \DOMDocument
      */
     private static function createSignature(
@@ -200,9 +204,11 @@ class Signer
      * @param string $content
      * @return string
      */
-    public static function removeSignature(string $content): string {
-        if (!self::existsSignature($content))
+    public static function removeSignature(string $content): string
+    {
+        if (!self::existsSignature($content)) {
             return $content;
+        }
 
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -227,12 +233,15 @@ class Signer
      * @return bool
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(string $content, string $tagname = '', $canonical = self::CANONICAL): bool {
-        if (!self::existsSignature($content))
+    public static function isSigned(string $content, string $tagname = '', $canonical = self::CANONICAL): bool
+    {
+        if (!self::existsSignature($content)) {
             return false;
+        }
 
-        if (!self::digestCheck($content, $tagname, $canonical))
+        if (!self::digestCheck($content, $tagname, $canonical)) {
             return false;
+        }
 
         return self::signatureCheck($content, $canonical);
     }
@@ -242,9 +251,11 @@ class Signer
      * @param string $content
      * @return boolean
      */
-    public static function existsSignature(string $content): bool {
-        if (!Validator::isXML($content))
+    public static function existsSignature(string $content): bool
+    {
+        if (!Validator::isXML($content)) {
             throw SignerException::isNotXml();
+        }
 
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -261,7 +272,8 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    private static function signatureCheck(string $xml, $canonical = self::CANONICAL): bool {
+    private static function signatureCheck(string $xml, $canonical = self::CANONICAL): bool
+    {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -286,8 +298,9 @@ class Signer
             str_replace(array("\r", "\n"), '', $signatureValue)
         );
 
-        if (!$publicKey->verify($signInfoNode, $decodedSignature, $algorithm))
+        if (!$publicKey->verify($signInfoNode, $decodedSignature, $algorithm)) {
             throw SignerException::signatureComparisonFailed();
+        }
 
         return true;
     }
@@ -300,7 +313,8 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    private static function digestCheck(string $xml, string $tagname = '', $canonical = self::CANONICAL): bool {
+    private static function digestCheck(string $xml, string $tagname = '', $canonical = self::CANONICAL): bool
+    {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
@@ -321,20 +335,23 @@ class Signer
                 foreach ($entries as $entry) {
                     $tagname = $entry->ownerElement->nodeName;
                     break;
-                }
+                } 
             }
             $node = $dom->getElementsByTagName($tagname)->item(0);            
-            if (empty($node))
+            if (empty($node)) {
                 throw SignerException::tagNotFound($tagname);
+            }
         }
         else {
             $node = $dom->getElementsByTagName($tagname)->item(0);
-            if (empty($node))
+            if (empty($node)) {
                 throw SignerException::tagNotFound($tagname);
+            }
             
             $signature = $node->nextSibling;
-            if ($signature->nodeName !== 'Signature')
+            if ($signature->nodeName !== 'Signature') {
                 throw SignerException::tagNotFound('Signature');
+            }
             
             $sigURI = $signature->getElementsByTagName('Reference')->item(0)->getAttribute('URI');
         }
@@ -353,8 +370,9 @@ class Signer
         $calculatedDigest = self::makeDigest($node, $algorithm, $canonical);
         $informedDigest = $signature->getElementsByTagName('DigestValue')->item(0)->nodeValue;
 
-        if ($calculatedDigest != $informedDigest)
+        if ($calculatedDigest != $informedDigest) {
             throw SignerException::digestComparisonFailed();
+        }
         
         return true;
     }
@@ -366,7 +384,8 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL): string {
+    private static function makeDigest(DOMNode $node, string $algorithm, $canonical = self::CANONICAL): string
+    {
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);
 
@@ -379,7 +398,8 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function canonize(DOMNode $node, $canonical = self::CANONICAL): string {
+    private static function canonize(DOMNode $node, $canonical = self::CANONICAL): string
+    {
         return $node->C14N(
             $canonical[0],
             $canonical[1],

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -323,19 +323,21 @@ class Signer
                     break;
                 }
             }
-            $node = $dom->getElementsByTagName($tagname)->item(0);
+            $node = $dom->getElementsByTagName($tagname)->item(0);            
+            if (empty($node))
+                throw SignerException::tagNotFound($tagname);
         }
         else {
             $node = $dom->getElementsByTagName($tagname)->item(0);
+            if (empty($node))
+                throw SignerException::tagNotFound($tagname);
+            
             $signature = $node->nextSibling;
             if ($signature->nodeName !== 'Signature')
                 throw SignerException::tagNotFound('Signature');
             
             $sigURI = $signature->getElementsByTagName('Reference')->item(0)->getAttribute('URI');
         }
-
-        if (empty($node))
-            throw SignerException::tagNotFound($tagname);
 
         $sigMethAlgo = $signature->getElementsByTagName('SignatureMethod')->item(0)->getAttribute('Algorithm');
         $algorithm = 'sha256';

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -32,7 +32,8 @@ use DOMElement;
 
 class Signer
 {
-    private static $canonical = [true,false,null,null];
+    const CANONICAL = [true,false,null,null];
+    private static $canonical = self::CANONICAL;
     
     /**
      * Make Signature tag
@@ -52,7 +53,7 @@ class Signer
         $tagname,
         $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = [true,false,null,null],
+        $canonical = self::CANONICAL,
         $rootname = ''
     ) {
         if (!empty($canonical)) {
@@ -109,7 +110,7 @@ class Signer
         DOMElement $node,
         $mark,
         $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
@@ -203,7 +204,7 @@ class Signer
     public static function isSigned(
         $content,
         $tagname = '',
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         if (self::existsSignature($content)) {
             if (self::digestCheck($content, $tagname, $canonical)) {
@@ -244,7 +245,7 @@ class Signer
      */
     public static function signatureCheck(
         $xml,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -287,7 +288,7 @@ class Signer
     public static function digestCheck(
         $xml,
         $tagname = '',
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -344,7 +345,7 @@ class Signer
     private static function makeDigest(
         DOMNode $node,
         $algorithm,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         //calcular o hash dos dados
         $c14n = self::canonize($node, $canonical);
@@ -360,7 +361,7 @@ class Signer
      */
     private static function canonize(
         DOMNode $node,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         return $node->C14N(
             $canonical[0],

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -131,7 +131,7 @@ class Signer
         Certificate $certificate,
         DOMDocument $dom,
         DOMElement $node,
-        string $mark = 'Id',
+        $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
     ) {

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -56,8 +56,7 @@ class Signer
         string $mark = 'Id',
         int $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument
-    {
+    ): DOMDocument {
         $signed = $doc;
 
         foreach ($tags as $tagName) {
@@ -101,8 +100,7 @@ class Signer
         string $mark = 'Id',
         int $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL
-    ): DOMDocument
-    {
+    ): DOMDocument {
         if (!empty($canonical)) {
             self::$canonical = $canonical;
         }
@@ -335,14 +333,13 @@ class Signer
                 foreach ($entries as $entry) {
                     $tagname = $entry->ownerElement->nodeName;
                     break;
-                } 
+                }
             }
-            $node = $dom->getElementsByTagName($tagname)->item(0);            
+            $node = $dom->getElementsByTagName($tagname)->item(0);
             if (empty($node)) {
                 throw SignerException::tagNotFound($tagname);
             }
-        }
-        else {
+        } else {
             $node = $dom->getElementsByTagName($tagname)->item(0);
             if (empty($node)) {
                 throw SignerException::tagNotFound($tagname);

--- a/src/Soap/SoapCurl.php
+++ b/src/Soap/SoapCurl.php
@@ -82,8 +82,7 @@ class SoapCurl extends SoapBase implements SoapInterface
             $response = curl_exec($curl);
 
             $httpcode = $this->dispose_curl($curl, $response, $data->urlMethod);
-        } 
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             throw SoapException::unableToLoadCurl($e->getMessage());
         }
 
@@ -98,7 +97,8 @@ class SoapCurl extends SoapBase implements SoapInterface
         return $this->responseBody;
     }
 
-    private static function buildParameters(SoapData $data): array {
+    private static function buildParameters(SoapData $data): array
+    {
         $msgSize = strlen($data->envelopedData);
         $parameters = array(
             "Content-Type: $data->contentType;charset=\"utf-8\"",

--- a/src/Soap/SoapCurl.php
+++ b/src/Soap/SoapCurl.php
@@ -17,6 +17,7 @@ namespace NFePHP\Common\Soap;
 
 use NFePHP\Common\Soap\SoapBase;
 use NFePHP\Common\Soap\SoapInterface;
+use NFePHP\Common\Soap\SoapData;
 use NFePHP\Common\Exception\SoapException;
 use NFePHP\Common\Certificate;
 use Psr\Log\LoggerInterface;
@@ -56,78 +57,57 @@ class SoapCurl extends SoapBase implements SoapInterface
         $request = '',
         $soapheader = null
     ) {
-        $response = '';
-        $envelope = $this->makeEnvelopeSoap(
-            $request,
-            $namespaces,
-            $soapver,
-            $soapheader
-        );
-        $msgSize = strlen($envelope);
-        $parameters = [
-            "Content-Type: application/soap+xml;charset=utf-8;",
-            "Content-length: $msgSize"
-        ];
-        if (!empty($action)) {
-            $parameters[0] .= "action=$action";
-        }
-        $this->requestHead = implode("\n", $parameters);
-        $this->requestBody = $envelope;
+        $data = new SoapData();
+        $data->urlService = $url;
+        $data->urlAction = $action;
+        $data->soapNamespaces = $namespaces;
+        $data->envelopedData = $this->makeEnvelopeSoap($request, $namespaces, $soapver, $soapheader);
+        $data->contentType = 'application/soap+xml';
+
+        return $this->send2($data);
+    }
+    
+    public function send2(SoapData $data): string {
+        $parameters = self::buildParameters($data);
+        $this->requestHead = implode('\n', $parameters);
+        $this->requestBody = $data->envelopedData;
+
+        $url = $data->urlService;
         
+        $httpcode = 0;
         try {
-            $oCurl = curl_init();
-            $this->setCurlProxy($oCurl);
-            curl_setopt($oCurl, CURLOPT_URL, $url);
-            curl_setopt($oCurl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-            curl_setopt($oCurl, CURLOPT_CONNECTTIMEOUT, $this->soaptimeout);
-            curl_setopt($oCurl, CURLOPT_TIMEOUT, $this->soaptimeout + 20);
-            curl_setopt($oCurl, CURLOPT_HEADER, 1);
-            curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 0);
-            curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);
-            if (!$this->disablesec) {
-                curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 2);
-                if (is_file($this->casefaz)) {
-                    curl_setopt($oCurl, CURLOPT_CAINFO, $this->casefaz);
-                }
-            }
-            curl_setopt($oCurl, CURLOPT_SSLVERSION, $this->soapprotocol);
-            curl_setopt($oCurl, CURLOPT_SSLCERT, $this->tempdir . $this->certfile);
-            curl_setopt($oCurl, CURLOPT_SSLKEY, $this->tempdir . $this->prifile);
-            if (!empty($this->temppass)) {
-                curl_setopt($oCurl, CURLOPT_KEYPASSWD, $this->temppass);
-            }
-            curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, 1);
-            if (!empty($envelope)) {
-                curl_setopt($oCurl, CURLOPT_POST, 1);
-                curl_setopt($oCurl, CURLOPT_POSTFIELDS, $envelope);
-                curl_setopt($oCurl, CURLOPT_HTTPHEADER, $parameters);
-            }
-            $response = curl_exec($oCurl);
-            $this->soaperror = curl_error($oCurl);
-            $ainfo = curl_getinfo($oCurl);
-            if (is_array($ainfo)) {
-                $this->soapinfo = $ainfo;
-            }
-            $headsize = curl_getinfo($oCurl, CURLINFO_HEADER_SIZE);
-            $httpcode = curl_getinfo($oCurl, CURLINFO_HTTP_CODE);
-            curl_close($oCurl);
-            $this->responseHead = trim(substr($response, 0, $headsize));
-            $this->responseBody = trim(substr($response, $headsize));
-            $this->saveDebugFiles(
-                $operation,
-                $this->requestHead . "\n" . $this->requestBody,
-                $this->responseHead . "\n" . $this->responseBody
-            );
-        } catch (\Exception $e) {
+            $curl = $this->create_curl($url, $data->envelopedData, $parameters);
+            
+            $response = curl_exec($curl);
+
+            $httpcode = $this->dispose_curl($curl, $response, $data->urlMethod);
+        }
+        catch(\Exception $e) {
             throw SoapException::unableToLoadCurl($e->getMessage());
         }
-        if ($this->soaperror != '') {
+
+        if ($this->soaperror != '')
             throw SoapException::soapFault($this->soaperror . " [$url]");
-        }
-        if ($httpcode != 200) {
+
+        if ($httpcode != 200)
             throw SoapException::soapFault(" [$url]" . $this->responseHead);
-        }
+
         return $this->responseBody;
+    }
+
+    private static function buildParameters(SoapData $data): array {
+        $msgSize = strlen($data->envelopedData);
+        $parameters = array(
+            "Content-Type: $data->contentType;charset=\"utf-8\"",
+            "Content-Length: $msgSize",
+        );
+        if (!empty($data->urlMethod)) {
+            $parameters[0] .= ";action=\"$data->urlMethod\"";
+        }
+        if (!empty($data->urlAction)) {
+            $parameters[] = "SOAPAction: $data->urlAction";
+        }        
+        return $parameters;
     }
     
     /**
@@ -145,5 +125,72 @@ class SoapCurl extends SoapBase implements SoapInterface
                 curl_setopt($oCurl, CURLOPT_PROXYAUTH, CURLAUTH_BASIC);
             }
         }
+    }
+    
+    private function create_curl($url, $envelope, $parameters)
+    {
+        $oCurl = curl_init();
+        $this->setCurlProxy($oCurl);
+        curl_setopt($oCurl, CURLOPT_URL, $url);
+        curl_setopt($oCurl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        curl_setopt($oCurl, CURLOPT_CONNECTTIMEOUT, $this->soaptimeout);
+        curl_setopt($oCurl, CURLOPT_TIMEOUT, $this->soaptimeout + 30);
+        curl_setopt($oCurl, CURLOPT_HEADER, 1);
+        curl_setopt($oCurl, CURLOPT_VERBOSE, 1);
+        // curl_setopt($oCurl, CURLOPT_FAILONERROR, 1);
+        curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);
+
+        if (!$this->disablesec) {
+            curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 2);
+            if (is_file($this->casefaz)) {
+                curl_setopt($oCurl, CURLOPT_CAINFO, $this->casefaz); //must have already called function loadCA at this point.
+            }
+        }
+
+        curl_setopt($oCurl, CURLOPT_SSLVERSION, $this->soapprotocol);
+        curl_setopt($oCurl, CURLOPT_SSLCERT, $this->tempdir . $this->certfile);
+        curl_setopt($oCurl, CURLOPT_SSLKEY, $this->tempdir . $this->prifile);
+
+        if (!empty($this->temppass)) {
+            curl_setopt($oCurl, CURLOPT_KEYPASSWD, $this->temppass);
+        }
+
+        curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, 1);
+
+        if (!empty($envelope)) {
+            curl_setopt($oCurl, CURLOPT_POST, 1);
+            curl_setopt($oCurl, CURLOPT_POSTFIELDS, $envelope);
+            curl_setopt($oCurl, CURLOPT_HTTPHEADER, $parameters);
+        }
+
+        return $oCurl;
+    }
+
+    private function dispose_curl($oCurl, $response, $operation = '')
+    {
+        $this->soaperror = curl_error($oCurl);
+        $ainfo = curl_getinfo($oCurl);
+
+        if (is_array($ainfo)) {
+            $this->soapinfo = $ainfo;
+        }
+
+        $headsize = curl_getinfo($oCurl, CURLINFO_HEADER_SIZE);
+        $httpcode = curl_getinfo($oCurl, CURLINFO_HTTP_CODE);
+        curl_close($oCurl);
+
+        if ($response) {
+            $this->responseHead = trim(substr($response, 0, $headsize));
+            $this->responseBody = trim(substr($response, $headsize));
+        }
+
+        $this->saveDebugFiles(
+            $operation,
+            $this->requestHead . "\n" . $this->requestBody,
+            $this->responseHead . "\n" . $this->responseBody
+        );
+        
+        return $httpcode;
     }
 }

--- a/src/Soap/SoapCurl.php
+++ b/src/Soap/SoapCurl.php
@@ -67,7 +67,8 @@ class SoapCurl extends SoapBase implements SoapInterface
         return $this->send2($data);
     }
     
-    public function send2(SoapData $data): string {
+    public function send2(SoapData $data): string
+    {
         $parameters = self::buildParameters($data);
         $this->requestHead = implode('\n', $parameters);
         $this->requestBody = $data->envelopedData;
@@ -81,16 +82,18 @@ class SoapCurl extends SoapBase implements SoapInterface
             $response = curl_exec($curl);
 
             $httpcode = $this->dispose_curl($curl, $response, $data->urlMethod);
-        }
-        catch(\Exception $e) {
+        } 
+        catch (\Exception $e) {
             throw SoapException::unableToLoadCurl($e->getMessage());
         }
 
-        if ($this->soaperror != '')
+        if ($this->soaperror != '') {
             throw SoapException::soapFault($this->soaperror . " [$url]");
+        }
 
-        if ($httpcode != 200)
+        if ($httpcode != 200) {
             throw SoapException::soapFault(" [$url]" . $this->responseHead);
+        }
 
         return $this->responseBody;
     }
@@ -106,7 +109,7 @@ class SoapCurl extends SoapBase implements SoapInterface
         }
         if (!empty($data->urlAction)) {
             $parameters[] = "SOAPAction: $data->urlAction";
-        }        
+        }
         return $parameters;
     }
     
@@ -127,7 +130,7 @@ class SoapCurl extends SoapBase implements SoapInterface
         }
     }
     
-    private function create_curl($url, $envelope, $parameters)
+    private function createCurl($url, $envelope, $parameters)
     {
         $oCurl = curl_init();
         $this->setCurlProxy($oCurl);
@@ -144,7 +147,7 @@ class SoapCurl extends SoapBase implements SoapInterface
         if (!$this->disablesec) {
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 2);
             if (is_file($this->casefaz)) {
-                curl_setopt($oCurl, CURLOPT_CAINFO, $this->casefaz); //must have already called function loadCA at this point.
+                curl_setopt($oCurl, CURLOPT_CAINFO, $this->casefaz);
             }
         }
 
@@ -167,7 +170,7 @@ class SoapCurl extends SoapBase implements SoapInterface
         return $oCurl;
     }
 
-    private function dispose_curl($oCurl, $response, $operation = '')
+    private function disposeCurl($oCurl, $response, $operation = '')
     {
         $this->soaperror = curl_error($oCurl);
         $ainfo = curl_getinfo($oCurl);

--- a/src/Soap/SoapData.php
+++ b/src/Soap/SoapData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace NFePHP\Common\Soap;
+
+class SoapData
+{
+    public $urlService;
+    public $urlMethod;
+    public $urlAction;
+    public $soapNamespaces;
+    public $objHeader;
+    public $envelopedData;
+    public $contentType;
+}

--- a/tests/SignerTest.php
+++ b/tests/SignerTest.php
@@ -99,7 +99,7 @@ class SignerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($actual);
     }
 
-    private static function getNFeDOMDocument(): DOMDocument
+    private static function getNFeDOMDocument()
     {
         $content = file_get_contents(__DIR__. '/fixtures/xml/NFe/35101158716523000119550010000000011003000000-nfe.xml');
 
@@ -111,7 +111,7 @@ class SignerTest extends \PHPUnit\Framework\TestCase
         return $doc;
     }
 
-    private static function getCertificate(): Certificate
+    private static function getCertificate()
     {
         $pfx = file_get_contents(__DIR__. '/fixtures/certs/certificado_teste.pfx');
         $certificate = Certificate::readPfx($pfx, 'associacao');


### PR DESCRIPTION
- [x] Introdução de constantes nos arquivos envolvidos;
- [x] Redução da complexidade ciclomática em alguns métodos;
- [x] Declaração do tipo nas assinaturas dos métodos;
- [x] Simplificado o método `sign` para evitar conversão de `$content` para `DOMDocument` dentro das funções;
- [x] Reduzido excesso de quebra de linhas;
- [x] Extração de métodos das rotinas de inicialização e finalização do `cUrl`.
- [x] Introdução de novo método de assinatura, de argumento simplificado;
- [ ] Testes do método `sign2`;
- [ ] Testes do método `signMultipleTags`;
- [x] Ajustes dos testes para casar com modificações;