### PR TITLE
Introdução da constante CANONICAL na classe Signer

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -32,7 +32,7 @@ use DOMElement;
 
 class Signer
 {
-    private static $canonical = [true,false,null,null];
+    const CANONICAL = [true,false,null,null];
     
     /**
      * Make Signature tag
@@ -52,12 +52,9 @@ class Signer
         $tagname,
         $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = [true,false,null,null],
+        $canonical = self::CANONICAL,
         $rootname = ''
     ) {
-        if (!empty($canonical)) {
-            self::$canonical = $canonical;
-        }
         if (empty($content)) {
             throw SignerException::isNotXml();
         }
@@ -109,7 +106,7 @@ class Signer
         DOMElement $node,
         $mark,
         $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
@@ -203,7 +200,7 @@ class Signer
     public static function isSigned(
         $content,
         $tagname = '',
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         if (self::existsSignature($content)) {
             if (self::digestCheck($content, $tagname, $canonical)) {
@@ -244,7 +241,7 @@ class Signer
      */
     public static function signatureCheck(
         $xml,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -287,7 +284,7 @@ class Signer
     public static function digestCheck(
         $xml,
         $tagname = '',
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
@@ -344,7 +341,7 @@ class Signer
     private static function makeDigest(
         DOMNode $node,
         $algorithm,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         //calcular o hash dos dados
         $c14n = self::canonize($node, $canonical);
@@ -360,7 +357,7 @@ class Signer
      */
     private static function canonize(
         DOMNode $node,
-        $canonical = [true,false,null,null]
+        $canonical = self::CANONICAL
     ) {
         return $node->C14N(
             $canonical[0],


### PR DESCRIPTION
A variável privada estática `$canonical` não está sendo consultada em lugar algum no código, e foi removida.

Também foi introduzido uma constante para definir o valor padrão para os argumentos `$canonical` das funções estáticas, uma vez que o valor padrão para todos os casos era igual.