### PR TITLE
Remoção estética do excesso de quebras de linha na classe Signer

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -58,7 +58,7 @@ class Signer
         if (empty($content)) {
             throw SignerException::isNotXml();
         }
-        if (! Validator::isXML($content)) {
+        if (!Validator::isXML($content)) {
             throw SignerException::isNotXml();
         }
         $dom = new DOMDocument('1.0', 'UTF-8');
@@ -73,7 +73,7 @@ class Signer
         if (empty($node) || empty($root)) {
             throw SignerException::tagNotFound($tagname);
         }
-        if (! self::existsSignature($content)) {
+        if (!self::existsSignature($content)) {
             $dom = self::createSignature(
                 $certificate,
                 $dom,
@@ -173,7 +173,7 @@ class Signer
      */
     public static function removeSignature($content)
     {
-        if (! self::existsSignature($content)) {
+        if (!self::existsSignature($content)) {
             return $content;
         }
         $dom = new \DOMDocument('1.0', 'utf-8');
@@ -197,11 +197,8 @@ class Signer
      * @return boolean
      * @throws SignerException Not is a XML, Digest or Signature dont match
      */
-    public static function isSigned(
-        $content,
-        $tagname = '',
-        $canonical = self::CANONICAL
-    ) {
+    public static function isSigned($content, $tagname = '', $canonical = self::CANONICAL)
+    {
         if (self::existsSignature($content)) {
             if (self::digestCheck($content, $tagname, $canonical)) {
                 if (self::signatureCheck($content, $canonical)) {
@@ -219,7 +216,7 @@ class Signer
      */
     public static function existsSignature($content)
     {
-        if (! Validator::isXML($content)) {
+        if (!Validator::isXML($content)) {
             throw SignerException::isNotXml();
         }
         $dom = new \DOMDocument('1.0', 'utf-8');
@@ -239,35 +236,25 @@ class Signer
      * @param array $canonical
      * @return boolean
      */
-    public static function signatureCheck(
-        $xml,
-        $canonical = self::CANONICAL
-    ) {
+    public static function signatureCheck($xml, $canonical = self::CANONICAL)
+    {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
         $dom->loadXML($xml);
         
         $signature = $dom->getElementsByTagName('Signature')->item(0);
-        $sigMethAlgo = $signature->getElementsByTagName('SignatureMethod')
-            ->item(0)->getAttribute('Algorithm');
+        $sigMethAlgo = $signature->getElementsByTagName('SignatureMethod')->item(0)->getAttribute('Algorithm');
         $algorithm = OPENSSL_ALGO_SHA256;
         if ($sigMethAlgo == 'http://www.w3.org/2000/09/xmldsig#rsa-sha1') {
             $algorithm = OPENSSL_ALGO_SHA1;
         }
-        $certificateContent = $signature->getElementsByTagName('X509Certificate')
-            ->item(0)->nodeValue;
+        $certificateContent = $signature->getElementsByTagName('X509Certificate')->item(0)->nodeValue;
         $publicKey = PublicKey::createFromContent($certificateContent);
-        $signInfoNode = self::canonize(
-            $signature->getElementsByTagName('SignedInfo')->item(0),
-            $canonical
-        );
-        $signatureValue = $signature->getElementsByTagName('SignatureValue')
-            ->item(0)->nodeValue;
-        $decodedSignature = base64_decode(
-            str_replace(array("\r", "\n"), '', $signatureValue)
-        );
-        if (! $publicKey->verify($signInfoNode, $decodedSignature, $algorithm)) {
+        $signInfoNode = self::canonize($signature->getElementsByTagName('SignedInfo')->item(0), $canonical);
+        $signatureValue = $signature->getElementsByTagName('SignatureValue')->item(0)->nodeValue;
+        $decodedSignature = base64_decode(str_replace(array("\r", "\n"), '', $signatureValue));
+        if (!$publicKey->verify($signInfoNode, $decodedSignature, $algorithm)) {
             throw SignerException::signatureComparisonFailed();
         }
         return true;
@@ -281,20 +268,15 @@ class Signer
      * @return bool
      * @throws SignerException
      */
-    public static function digestCheck(
-        $xml,
-        $tagname = '',
-        $canonical = self::CANONICAL
-    ) {
+    public static function digestCheck($xml, $tagname = '', $canonical = self::CANONICAL)
+    {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = false;
         $dom->preserveWhiteSpace = false;
         $dom->loadXML($xml);
         $root = $dom->documentElement;
         $signature = $dom->getElementsByTagName('Signature')->item(0);
-        $sigURI = $signature->getElementsByTagName('Reference')
-            ->item(0)
-            ->getAttribute('URI');
+        $sigURI = $signature->getElementsByTagName('Reference')->item(0)->getAttribute('URI');
         if (empty($tagname)) {
             if (empty($sigURI)) {
                 $tagname = $root->nodeName;
@@ -311,9 +293,7 @@ class Signer
         if (empty($node)) {
             throw SignerException::tagNotFound($tagname);
         }
-        $sigMethAlgo = $signature->getElementsByTagName('SignatureMethod')
-            ->item(0)
-            ->getAttribute('Algorithm');
+        $sigMethAlgo = $signature->getElementsByTagName('SignatureMethod')->item(0)->getAttribute('Algorithm');
         $algorithm = 'sha256';
         if ($sigMethAlgo == 'http://www.w3.org/2000/09/xmldsig#rsa-sha1') {
             $algorithm = 'sha1';
@@ -322,9 +302,7 @@ class Signer
             $node->removeChild($signature);
         }
         $calculatedDigest = self::makeDigest($node, $algorithm, $canonical);
-        $informedDigest = $signature->getElementsByTagName('DigestValue')
-            ->item(0)
-            ->nodeValue;
+        $informedDigest = $signature->getElementsByTagName('DigestValue')->item(0)->nodeValue;
         if ($calculatedDigest != $informedDigest) {
             throw SignerException::digestComparisonFailed();
         }
@@ -338,11 +316,8 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function makeDigest(
-        DOMNode $node,
-        $algorithm,
-        $canonical = self::CANONICAL
-    ) {
+    private static function makeDigest(DOMNode $node, $algorithm, $canonical = self::CANONICAL)
+    {
         //calcular o hash dos dados
         $c14n = self::canonize($node, $canonical);
         $hashValue = hash($algorithm, $c14n, true);
@@ -355,10 +330,8 @@ class Signer
      * @param array $canonical
      * @return string
      */
-    private static function canonize(
-        DOMNode $node,
-        $canonical = self::CANONICAL
-    ) {
+    private static function canonize(DOMNode $node, $canonical = self::CANONICAL)
+    {
         return $node->C14N(
             $canonical[0],
             $canonical[1],


### PR DESCRIPTION
Remoção de quebras de linhas para algumas funções e chamadas de métodos, para melhorar a estética de leitura de código. Também removido espaços após o `!`.