### PR TITLE
Escapando os parenteses replaceSpecialsChars

### DIFF
--- a/src/Strings.php
+++ b/src/Strings.php
@@ -28,7 +28,7 @@ class Strings
         $aSubs = ['e','a','a','a','a','e','e','i','o','o','o','u','u',
             'c','A','A','A','A','E','E','I','O','O','O','U','U','C'];
         $newstr = str_replace($aFind, $aSubs, $string);
-        $newstr = preg_replace("/[^a-zA-Z0-9 @,-_.;:\/]/", "", $newstr);
+        $newstr = preg_replace("/[^a-zA-Z0-9 @,-_.;:()\/]/", "", $newstr);
         return $newstr;
     }
     


### PR DESCRIPTION
O método estava removendo os parenteses do campo infAdProd dos itens da nota, o certo seria isso
```xml
<infAdProd>( 02 BALDES 130X130X10200 )</infAdProd>
```
mas estava ficando assim
```xml
<infAdProd> 02 BALDES 130X130X10200 </infAdProd>
```
E também como o trim estava rodando antes do preg_replace ficava os espaços no inicio e no fim, ai dava erro o validador da lib.