### PR TITLE
Adicionado função Strings::replaceLineBreak($txt)

### DIFF
--- a/src/Strings.php
+++ b/src/Strings.php
@@ -219,4 +219,15 @@ class Strings
         }
         return $str;
     }
+
+    /**
+     * Swaps all line breaks per character ';'
+     * @param string $txt
+     * @return string
+     */
+    public static function replaceLineBreak($txt)
+    {
+		$str = preg_replace('/\r\n?/', ';', $txt);
+		return preg_replace('/\r|\n/', ';', $str);
+    }
 }

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -82,4 +82,12 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $expected .= "ZV|\n";
         $this->assertEquals($expected, $actual);
     }
+
+    public function testReplaceLineBreak()
+    {
+        $txt = "Texto com quebra de linha \n e mais uma quebra de linha \r e outra quebra de linha \r\n, nossa, como tem quebras de linhas nesse texto r n teste";
+        $txtOk = "Texto com quebra de linha ; e mais uma quebra de linha ; e outra quebra de linha ;, nossa, como tem quebras de linhas nesse texto r n teste";
+        $resp = Strings::replaceLineBreak($txt);
+        $this->assertEquals($txtOk, $resp);
+    }
 }


### PR DESCRIPTION
Adicionei na classe Strings a função replaceLineBreak.
Essa função vai ser utilizada no projeto da NF-e (/nfephp-org/sped-nfe) para o preenchimento das tags infAdFisco e infCpl.
Pois ao preencher as mesmas com uma quebra de linha, gera o erro :
conteudo..  is not accepted by the pattern '[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}'
Para gerar uma quebra de linha., devemos trocar a quebra de linha pelo caractere ";" (ponto e virgula).


Veja: https://github.com/nfephp-org/sped-nfe/pull/564