### PR TITLE
adição da tag X509SubjectName na assinatura

### DIFF
--- a/src/Certificate/PublicKey.php
+++ b/src/Certificate/PublicKey.php
@@ -105,6 +105,7 @@ CONTENT;
         if (isset($detail['name'])) {
             $arrayName = explode("/",$detail["name"]);
             $arrayName = array_reverse($arrayName);
+            $arrayName = array_filter($arrayName);
             $name = implode(",",$arrayName);
             $this->subjectNameValue = $name;
         }

--- a/src/Certificate/PublicKey.php
+++ b/src/Certificate/PublicKey.php
@@ -44,6 +44,10 @@ class PublicKey implements VerificationInterface
      * @var string
      */
     public $serialNumber;
+    /**
+     * @var string
+     */
+    public $subjectNameValue;
 
     /**
      * PublicKey constructor.
@@ -98,6 +102,12 @@ CONTENT;
         $this->serialNumber = $detail['serialNumber'];
         $this->validFrom = \DateTime::createFromFormat('ymdHis\Z', $detail['validFrom']);
         $this->validTo = \DateTime::createFromFormat('ymdHis\Z', $detail['validTo']);
+        if (isset($detail['name'])) {
+            $arrayName = explode("/",$detail["name"]);
+            $arrayName = array_reverse($arrayName);
+            $name = implode(",",$arrayName);
+            $this->subjectNameValue = $name;
+        }
     }
 
     /**

--- a/src/Signer.php
+++ b/src/Signer.php
@@ -53,7 +53,8 @@ class Signer
         $mark = 'Id',
         $algorithm = OPENSSL_ALGO_SHA1,
         $canonical = self::CANONICAL,
-        $rootname = ''
+        $rootname = '',
+        $options = []
     ) {
         if (empty($content)) {
             throw SignerException::isNotXml();
@@ -81,7 +82,8 @@ class Signer
                 $node,
                 $mark,
                 $algorithm,
-                $canonical
+                $canonical,
+                $options
             );
         }
         return $dom->saveXML($dom->documentElement, LIBXML_NOXMLDECL);
@@ -105,7 +107,8 @@ class Signer
         DOMElement $node,
         $mark,
         $algorithm = OPENSSL_ALGO_SHA1,
-        $canonical = self::CANONICAL
+        $canonical = self::CANONICAL,
+        $options = []
     ) {
         $nsDSIG = 'http://www.w3.org/2000/09/xmldsig#';
         $nsCannonMethod = 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315';
@@ -159,6 +162,13 @@ class Signer
         $signatureNode->appendChild($keyInfoNode);
         $x509DataNode = $dom->createElement('X509Data');
         $keyInfoNode->appendChild($x509DataNode);
+
+        if(!empty($options["subjectName"])) {
+            $subjectName = $certificate->publicKey->subjectNameValue;
+            $x509SubjectNode = $dom->createElement('X509SubjectName', $subjectName);
+            $x509DataNode->appendChild($x509SubjectNode);
+        }
+
         $pubKeyClean = $certificate->publicKey->unFormated();
         $x509CertificateNode = $dom->createElement('X509Certificate', $pubKeyClean);
         $x509DataNode->appendChild($x509CertificateNode);


### PR DESCRIPTION
foi adicionada a OPÇÃO de escolher se deve gerar a tag X509SubjectName ou nao, essa tag não é usada na NFE mas é obrigatoria em assinaturas para algumas prefeituras na emissão de NFSe, estamos usando essa maravilhosa classe pra assinar os RPS, porém faltava essa tag obrigatoria
essa alteração não modifica o funcionamento de nada que já esteja funcionando. gostaria de sugerir a alteração para que possamos adotar sempre a versão padrão da sped-common como nossa assinadora, sem ter que ficar fazendo alterações, além de talvez ajudar outros programadores no futuro.