### PR TITLE
Ajuste no método addChild para não incluir erros quando a criação do …

### DIFF
--- a/src/DOMImproved.php
+++ b/src/DOMImproved.php
@@ -176,7 +176,7 @@ class DOMImproved extends DOMDocument
         }
         if (!$obrigatorio && $content === null) {
             return;
-        } elseif ($obrigatorio && ($content === null || $content === '')) {
+        } elseif ($obrigatorio && ($content === null || $content === '') && !$force) {
             $this->errors[] = "Preenchimento Obrigatório! [$name] $descricao";
         }
         $content = (string) $content;


### PR DESCRIPTION
…elemento é forçada

Se o erro é incluído mesmo quando a criação do elemento é forçada, não há como montar o XML no sped-nfe: https://github.com/nfephp-org/sped-nfe/blob/bdb6ebe17828c8d8617df11eadfc5b17c73f030f/src/Make.php#L382

Por exemplo, no caso da tag idEstrangeiro, se for enviado um valor vazio '', o XML não é criado (no método monta), pois o erro é incluído sem considerar a variável $force