### PR TITLE
Tratamento de caracteres especiais

### DIFF
--- a/src/DOMImproved.php
+++ b/src/DOMImproved.php
@@ -182,7 +182,8 @@ class DOMImproved extends DOMDocument
         $content = (string) $content;
         $content = trim($content);
         if ($obrigatorio || $content !== '' || $force) {
-            $temp = $this->createElement($name, $content);
+            $temp = $this->createElement($name, '');
+            $temp->{$name} = $content;
             $parent->appendChild($temp);
         }
     }

--- a/src/DOMImproved.php
+++ b/src/DOMImproved.php
@@ -182,8 +182,13 @@ class DOMImproved extends DOMDocument
         $content = (string) $content;
         $content = trim($content);
         if ($obrigatorio || $content !== '' || $force) {
-            $temp = $this->createElement($name, '');
-            $temp->{$name} = $content;
+            if(stristr($content, '&') !== false ) {
+                $temp = $this->createElement($name);
+                $nodeTxt = $this->createTextNode($content);
+                $temp->appendChild($nodeTxt);                
+            } else {
+                $temp = $this->createElement($name, $content);
+            }
             $parent->appendChild($temp);
         }
     }


### PR DESCRIPTION
Boa tarde.
Alguns fabricantes de peças possuem caracteres especiais na formação de seus codigos, exemplo: P&A1273 (Anel CAL1016), quando ocorre de existir este casos com o caracteres & < >  "" '' é retornado o erro DOMDocument::createElement(): unterminated entity reference.

Alterando o fonte para criar primeiro o elemento de depois alimentar o conteudo o erro não acontece:
if ($obrigatorio || $content !== '' || $force) {
            if(stristr($content, '&') !== false ) {
                $temp = $this->createElement($name);
                $nodeTxt = $this->createTextNode($content);
                $temp->appendChild($nodeTxt);                
            } else {
                $temp = $this->createElement($name, $content);
            }
            $parent->appendChild($temp);
        }

Ou se tratarmos a variavel $content com a função htmlspecialchars(), mas neste caso eu entendo que nem todo o conteudo ira vir de uma pagina html.

$content = (string) $content;
$content = trim($content);
$content = htmlspecialchars($content);
if ($obrigatorio || $content !== '' || $force) {
    $temp = $this->createElement($name, $content);
    $parent->appendChild($temp);
}