### PR TITLE
Substituição de caractere &

### DIFF
--- a/src/Strings.php
+++ b/src/Strings.php
@@ -16,7 +16,7 @@ use ForceUTF8\Encoding;
 
 class Strings
 {
-    
+
     /**
      * Includes missing or unsupported properties in stdClass inputs
      * and Replace all unsuported chars
@@ -59,7 +59,7 @@ class Strings
         $string = preg_replace("/[^a-zA-Z0-9 @#,-_.;:$%\/]/", "", $string);
         return preg_replace("/[<>]/", "", $string);
     }
-    
+
     /**
      * Clear inputs for build in XML
      * Only UTF-8 characters is acceptable
@@ -79,14 +79,14 @@ class Strings
         //& isolated, less than, greater than, quotation marks and apostrophes
         //should be replaced by their html equivalent
         $input = str_replace(
-            ['& ','<','>','"',"'"],
-            ['&amp; ','&lt;','&gt;','&quot;','&#39;'],
+            ['&','<','>','"',"'"],
+            ['&amp;','&lt;','&gt;','&quot;','&#39;'],
             $input
         );
         $input = self::normalize($input);
         return trim($input);
     }
-    
+
     /**
      * Converts all UTF-8 remains in ASCII
      * @param string $input
@@ -98,7 +98,7 @@ class Strings
         $input = self::squashCharacters($input);
         return mb_convert_encoding($input, 'ascii');
     }
-    
+
     /**
      * Replaces all accented characters of their ASCII equivalents
      * @param string $input
@@ -113,7 +113,7 @@ class Strings
             'c','A','A','A','A','E','E','I','O','O','O','U','U','C'];
         return str_replace($aFind, $aSubs, $input);
     }
-    
+
     /**
      * Replace all non-UTF-8 chars to UTF-8
      * Remove all control chars
@@ -153,7 +153,7 @@ class Strings
     {
         return preg_replace("/[^0-9]/", "", $string);
     }
-    
+
     /**
      * Remove unwanted attributes, prefixes, sulfixes and other control
      * characters like \r \n \s \t
@@ -179,7 +179,7 @@ class Strings
         }
         return $retXml;
     }
-    
+
     /**
      * Remove all characters between markers
      * @param string $string
@@ -197,7 +197,7 @@ class Strings
         $textToDelete = substr($string, $beginningPos, ($endPos + strlen($end)) - $beginningPos);
         return str_replace($textToDelete, '', $string);
     }
-    
+
     /**
      * Clears the xml after adding the protocol, removing repeated namespaces
      * @param string $string
@@ -216,7 +216,7 @@ class Strings
         }
         return $procXML;
     }
-    
+
     /**
      * Remove some alien chars from txt
      * @param string $txt
@@ -232,7 +232,7 @@ class Strings
         $txt = str_replace(["| "," |"], "|", $txt);
         return $txt;
     }
-    
+
     /**
      * Creates a string ramdomically with the specified length
      * @param int $length

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -5,7 +5,7 @@ use NFePHP\Common\Strings;
 class StringsTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_XML_PATH = '/fixtures/xml/';
-    
+
     public function testReplaceSpecialsChars()
     {
         $txtSujo = "Esse é um código cheio de @$#$! , - . ; : / COISAS e 12093876486";
@@ -13,16 +13,16 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $resp = Strings::replaceSpecialsChars($txtSujo);
         $this->assertEquals($txtLimpo, $resp);
     }
-    
+
     public function testReplaceUnacceptableCharacters()
     {
-        $txtSujo = "Contribuições R$   200,00  @ # * IPI: 15% Caixa D'agua Rico   & Rich < > \"   \t \r \n ";
+        $txtSujo = "Contribuições R$   200,00  @ # * IPI: 15% Caixa D'agua Rico   & && Rich < > \"   \t \r \n ";
         $txtSujo .= mb_convert_encoding(" teste ç Á ã é ø", 'ISO-8859-1');
-        $txtLimpo = "Contribuições R$ 200,00 @ # * IPI: 15% Caixa D&#39;agua Rico &amp; Rich &lt; &gt; &quot; teste ç Á ã é ø";
+        $txtLimpo = "Contribuições R$ 200,00 @ # * IPI: 15% Caixa D&#39;agua Rico &amp; &amp;&amp; Rich &lt; &gt; &quot; teste ç Á ã é ø";
         $resp = Strings::replaceUnacceptableCharacters($txtSujo);
         $this->assertEquals($txtLimpo, $resp);
     }
-    
+
     public function testClearXmlString()
     {
         $xmlSujo = file_get_contents(__DIR__. self::TEST_XML_PATH . 'NFe/xml-sujo.xml');
@@ -37,7 +37,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($xmlLimpo2, $resp2);
         $this->assertEquals($txtLimpo, $resp3);
     }
-    
+
     public function testClearProtocoledXML()
     {
         $xmlSujo = '';
@@ -45,21 +45,21 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $resp1 = Strings::clearProtocoledXML($xmlSujo);
         $this->assertEquals($xmlLimpo, $resp1);
     }
-    
+
     public function testOnlyNumbers()
     {
         $expected = '123657788';
         $actual = Strings::onlyNumbers('123-65af77./88 Ç $#');
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testRandomString()
     {
         $str = Strings::randomString(10);
         $len = strlen($str);
         $this->assertEquals($len, 10);
     }
-    
+
     public function testDeleteAllBetween()
     {
         $str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -70,7 +70,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $expected = "<soap:Envelope><soap:Body></soap:Body></soap:Envelope>";
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testRemoveSomeAlienCharsfromTxt()
     {
         $txt = "C|PLASTFOAM                   IND. E       COM DE PLASTICOS LTDA|PLASTFOAM| 336546371113||184394 |2222600|3 |\n";


### PR DESCRIPTION
- [CORRETIVA] Removendo espaço em branco logo após o caractere & para que ocorra a substituição na string quando o input de entrada for "&&", "&&&", ... e o caso padrão "&"