### PR TITLE
PHP 7 preg_replace modificador u

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0snapshot
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-dist: precise
+dist: xenial
 sudo: false
 
 before_script:

--- a/src/Strings.php
+++ b/src/Strings.php
@@ -16,7 +16,7 @@ use ForceUTF8\Encoding;
 
 class Strings
 {
-    
+
     /**
      * Includes missing or unsupported properties in stdClass inputs
      * and Replace all unsuported chars
@@ -59,7 +59,7 @@ class Strings
         $string = preg_replace("/[^a-zA-Z0-9 @#,-_.;:$%\/]/", "", $string);
         return preg_replace("/[<>]/", "", $string);
     }
-    
+
     /**
      * Clear inputs for build in XML
      * Only UTF-8 characters is acceptable
@@ -88,7 +88,7 @@ class Strings
         $input = self::normalize($input);
         return trim($input);
     }
-    
+
     /**
      * Converts all UTF-8 remains in ASCII
      * @param string $input
@@ -100,7 +100,7 @@ class Strings
         $input = self::squashCharacters($input);
         return mb_convert_encoding($input, 'ascii');
     }
-    
+
     /**
      * Replaces all accented characters of their ASCII equivalents
      * @param string $input
@@ -115,7 +115,7 @@ class Strings
             'c','A','A','A','A','E','E','I','O','O','O','O','U','U','C'];
         return str_replace($aFind, $aSubs, $input);
     }
-    
+
     /**
      * Replace all non-UTF-8 chars to UTF-8
      * Remove all control chars
@@ -143,7 +143,7 @@ class Strings
         $input = preg_replace('/\xE0[\x80-\x9F][\x80-\xBF]'.
             '|\xED[\xA0-\xBF][\x80-\xBF]/S', '', $input);
         //And no other control character is acceptable either
-        return preg_replace('/[[:cntrl:]]/', '', $input);
+        return preg_replace('/[[:cntrl:]]/u', '', $input);
     }
 
     /**
@@ -155,7 +155,7 @@ class Strings
     {
         return preg_replace("/[^0-9]/", "", $string);
     }
-    
+
     /**
      * Remove unwanted attributes, prefixes, sulfixes and other control
      * characters like \r \n \s \t
@@ -181,7 +181,7 @@ class Strings
         }
         return $retXml;
     }
-    
+
     /**
      * Remove all characters between markers
      * @param string $string
@@ -199,7 +199,7 @@ class Strings
         $textToDelete = substr($string, $beginningPos, ($endPos + strlen($end)) - $beginningPos);
         return str_replace($textToDelete, '', $string);
     }
-    
+
     /**
      * Clears the xml after adding the protocol, removing repeated namespaces
      * @param string $string
@@ -218,7 +218,7 @@ class Strings
         }
         return $procXML;
     }
-    
+
     /**
      * Remove some alien chars from txt
      * @param string $txt
@@ -234,7 +234,7 @@ class Strings
         $txt = str_replace(["| "," |"], "|", $txt);
         return $txt;
     }
-    
+
     /**
      * Creates a string ramdomically with the specified length
      * @param int $length

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -5,7 +5,7 @@ use NFePHP\Common\Strings;
 class StringsTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_XML_PATH = '/fixtures/xml/';
-    
+
     public function testReplaceSpecialsChars()
     {
         $txtSujo = "Esse é um código cheio de @$#$! , - . ; : / COISAS e 12093876486";
@@ -13,7 +13,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $resp = Strings::replaceSpecialsChars($txtSujo);
         $this->assertEquals($txtLimpo, $resp);
     }
-    
+
     public function testReplaceUnacceptableCharacters()
     {
         $txtSujo = "Contribuições R$   200,00  @ # * IPI: 15% Caixa D'agua Rico   & Rich < > \"   \t \r \n ";
@@ -22,7 +22,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $resp = Strings::replaceUnacceptableCharacters($txtSujo);
         $this->assertEquals($txtLimpo, $resp);
     }
-    
+
     public function testClearXmlString()
     {
         $xmlSujo = file_get_contents(__DIR__. self::TEST_XML_PATH . 'NFe/xml-sujo.xml');
@@ -37,7 +37,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($xmlLimpo2, $resp2);
         $this->assertEquals($txtLimpo, $resp3);
     }
-    
+
     public function testClearProtocoledXML()
     {
         $xmlSujo = '';
@@ -45,21 +45,21 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $resp1 = Strings::clearProtocoledXML($xmlSujo);
         $this->assertEquals($xmlLimpo, $resp1);
     }
-    
+
     public function testOnlyNumbers()
     {
         $expected = '123657788';
         $actual = Strings::onlyNumbers('123-65af77./88 Ç $#');
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testRandomString()
     {
         $str = Strings::randomString(10);
         $len = strlen($str);
         $this->assertEquals($len, 10);
     }
-    
+
     public function testDeleteAllBetween()
     {
         $str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -70,7 +70,7 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $expected = "<soap:Envelope><soap:Body></soap:Body></soap:Envelope>";
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testRemoveSomeAlienCharsfromTxt()
     {
         $txt = "C|PLASTFOAM                   IND. E       COM DE PLASTICOS LTDA|PLASTFOAM| 336546371113||184394 |2222600|3 |\n";
@@ -82,4 +82,27 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $expected .= "ZV|\n";
         $this->assertEquals($expected, $actual);
     }
+
+    public function testNormalize()
+    {
+        $input = 'CABEÇÃO';
+        $actual = Strings::normalize($input);
+        $this->assertEquals($input, $actual);
+
+        $input = "\tREPÚBLICA FEDERATIVA DO BRASIL\r\n";
+        $expected = 'REPÚBLICA FEDERATIVA DO BRASIL';
+        $actual = Strings::normalize($input);
+        $this->assertEquals($expected, $actual);
+
+        $input = " REPÚBLICA  FEDERATIVA   DO    BRASIL";
+        $expected = ' REPÚBLICA FEDERATIVA DO BRASIL';
+        $actual = Strings::normalize($input);
+        $this->assertEquals($expected, $actual);
+
+        $input = "REPÚBLICA \u{001F} FEDERATIVA DO BRASIL \u{000A}";
+        $expected = 'REPÚBLICA  FEDERATIVA DO BRASIL ';
+        $actual = Strings::normalize($input);
+        $this->assertEquals($expected, $actual);
+    }
+
 }


### PR DESCRIPTION
- [CORRETIVA] PHP 7 `preg_replace('/[[:cntrl:]]/u', '', $input)`
substitui caractere por ponto de interrogação �
- [EVOLUTIVA] Testes unitários para o método `normalize`