### PR TITLE
Definir CURL_HTTP_VERSION_1_1 caso for NULL

### DIFF
--- a/src/Soap/SoapCurl.php
+++ b/src/Soap/SoapCurl.php
@@ -87,7 +87,8 @@ class SoapCurl extends SoapBase implements SoapInterface
             curl_setopt($oCurl, CURLOPT_CONNECTTIMEOUT, $this->soaptimeout);
             curl_setopt($oCurl, CURLOPT_TIMEOUT, $this->soaptimeout + 20);
             curl_setopt($oCurl, CURLOPT_HEADER, 1);
-            curl_setopt($oCurl, CURLOPT_HTTP_VERSION, $this->httpver);
+            if ( is_null($this->httpver) ) curl_setopt($oCurl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+            else curl_setopt($oCurl, CURLOPT_HTTP_VERSION, $this->httpver);
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 0);
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);
             if (!$this->disablesec) {


### PR DESCRIPTION
Em um servidor encontrei o problema HTTP_1_1_REQUIRED (err 13).
Descrito em https://github.com/nfephp-org/sped-common/blob/master/docs/Soap/SoapCurl.md 
Não encontrei como deixar como padrão o CURL_HTTP_VERSION_1_1 no nfephp, conforme alterei no código caso seja NULL.
No stdClass da configuração alguma opção para isso?