### PR TITLE
Ajuste em SoapCurl.php

### DIFF
--- a/src/Soap/SoapCurl.php
+++ b/src/Soap/SoapCurl.php
@@ -118,6 +118,7 @@ class SoapCurl extends SoapBase implements SoapInterface
             curl_close($oCurl);
             $this->responseHead = trim(substr($response, 0, $headsize));
             $this->responseBody = trim(substr($response, $headsize));
+            $this->setDebugMode(true);
             $this->saveDebugFiles(
                 $operation,
                 $this->requestHead . "\n" . $this->requestBody,


### PR DESCRIPTION
O método _SoapBase::saveDebugFiles_ não armazena os dados enviados por parâmetro se o atributo _SoapBase::$debugmode_ não for **true**.