### PR TITLE
Alterada ordem dos parâmetros do domDocument no assinador

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -63,9 +63,9 @@ class Signer
             throw SignerException::isNotXml();
         }
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->loadXML($content);
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput = false;
+        $dom->loadXML($content);
         $root = $dom->documentElement;
         if (!empty($rootname)) {
             $root = $dom->getElementsByTagName($rootname)->item(0);


### PR DESCRIPTION
Alterada ordem de alteração dos parâmetros preserveWhiteSpace e formatOutput, pois eles não tem efeito se alterados após o carregamento do XML