### PR TITLE
Adiciona verificação para tratamento de variáveis nulas na função onlyNumbers()

### DIFF
--- a/src/Strings.php
+++ b/src/Strings.php
@@ -158,9 +158,12 @@ class Strings
      */
     public static function onlyNumbers($string)
     {
+        if (is_null($string)) {
+            return "";
+        }
         return preg_replace("/[^0-9]/", "", $string);
     }
-
+    
     /**
      * Remove unwanted attributes, prefixes, sulfixes and other control
      * characters like \r \n \s \t


### PR DESCRIPTION
Descrição das alterações:

Esta alteração propõe uma correção para o problema de passagem de valores nulos para a função onlyNumbers() da biblioteca SPED PHP. Quando é passada uma variável nula para a função onlyNumbers(), ela retorna um valor nulo, o que pode causar erros em outras partes do código que esperam uma string. Além disso, com o PHP 8.0, a passagem de valores nulos para funções que esperam uma string pode gerar um erro de tipo.

Para corrigir esses problemas, esta alteração adiciona uma verificação no início da função onlyNumbers() para verificar se a variável passada é nula. Se for nula, a função retorna uma string vazia ("") em vez de fazer a operação preg_replace(). Caso contrário, a função continua executando a operação preg_replace() normalmente.

Motivação:

Esta alteração foi proposta para melhorar a robustez e a estabilidade da biblioteca SPED PHP, evitando erros causados por valores nulos passados para a função onlyNumbers(). Além disso, com o PHP 8.0, é necessário garantir que as funções lidem adequadamente com valores nulos para evitar erros de tipo.