### PR TITLE
resolvendo problema da validacao de campos com caracteres especiais 

### DIFF
--- a/src/DOMImproved.php
+++ b/src/DOMImproved.php
@@ -183,7 +183,7 @@ class DOMImproved extends DOMDocument
         $content = (string) $content;
         $content = trim($content);
         if ($obrigatorio || $content !== '' || $force) {
-            $temp = $this->createElement($name, $content);
+            $temp = $this->createElement($name, htmlspecialchars($content, ENT_QUOTES));
             $parent->appendChild($temp);
         }
     }


### PR DESCRIPTION
Os valores dos campos podem aceitar caracteres com %& mas da forma que foi implementado a validação não podemos passar os dados com o htmlspecialchars, pois aumentaria o tamanho do campo, então dessa forma resolve o problema
