### PR TITLE
Ajuste para certificados A1 funcionarem corretamente no debian 12

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -59,7 +59,7 @@ class Certificate implements SignatureInterface, VerificationInterface
     public static function readPfx($content, $password)
     {
         $certs = [];
-        if (!openssl_pkcs12_read($content, $certs, $password)) {
+        if (!pkcs12Read($content, $certs, $password)) {
             throw CertificateException::unableToRead();
         }
         $chain = '';
@@ -73,6 +73,44 @@ class Certificate implements SignatureInterface, VerificationInterface
             new PublicKey($certs['cert']),
             new CertificationChain($chain)
         );
+    }
+    /**
+     * Function that analyzes an array of pkcs12 certificates
+     * @param string $certificate
+     * @param array $certInfo
+     * @param string $password
+     * @return array|string[]
+     */
+    function pkcs12Read(string $certificate, array &$certInfo, string $password): bool
+    {
+        if (openssl_pkcs12_read($certificate, $certInfo, $password)) {
+            return true;
+        }
+        $msg = openssl_error_string();
+        if ($msg === 'error:0308010C:digital envelope routines::unsupported') {
+            if (!shell_exec('openssl version')) {
+                return false;
+            }
+            $tempPassword = tempnam(sys_get_temp_dir(), 'pfx');
+            $tempEncriptedOriginal = tempnam(sys_get_temp_dir(), 'original');
+            $tempEncriptedRepacked = tempnam(sys_get_temp_dir(), 'repacked');
+            $tempDecrypted = tempnam(sys_get_temp_dir(), 'decripted');
+            file_put_contents($tempPassword, $password);
+            file_put_contents($tempEncriptedOriginal, $certificate);
+            shell_exec(<<<REPACK_COMMAND
+                cat $tempPassword | openssl pkcs12 -legacy -in $tempEncriptedOriginal -nodes -out $tempDecrypted -passin stdin &&
+                cat $tempPassword | openssl pkcs12 -in $tempDecrypted -export -out $tempEncriptedRepacked -passout stdin
+                REPACK_COMMAND
+            );
+            $certificateRepacked = file_get_contents($tempEncriptedRepacked);
+            unlink($tempPassword);
+            unlink($tempEncriptedOriginal);
+            unlink($tempEncriptedRepacked);
+            unlink($tempDecrypted);
+            openssl_pkcs12_read($certificateRepacked, $certInfo, $password);
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Algumas cifras legadas foram desabilitadas na versão openssl do Debian 12 incluindo a que é utilizada pelos certificados A1, para não precisarmos reabilitar cifras legadas diretamente no servidor, ativando diversas outras que não são recomendadas, durante a execução, pode-se adicionar o argumento -legacy ao comando