### PR TITLE
Corrige timezone de validFrom/validTo do certificado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Setup PHP
@@ -64,6 +64,11 @@ jobs:
         if: matrix.php-version == '8.4'
         run: |
             composer stan84
+
+      - name: Análises estáticas PHP 8.5
+        if: matrix.php-version == '8.5'
+        run: |
+            composer stan85
 
       - name: Rodando PHPUnit
         run: |

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "stan81": "phpstan analyse src/ -c phpstan81.neon",
         "stan82": "phpstan analyse src/ -c phpstan82.neon",
         "stan83": "phpstan analyse src/ -c phpstan83.neon",
-        "stan84": "phpstan analyse src/ -c phpstan84.neon"
+        "stan84": "phpstan analyse src/ -c phpstan84.neon",
+        "stan85": "phpstan analyse src/ -c phpstan85.neon"
     }
 }

--- a/phpstan-baseline85.neon
+++ b/phpstan-baseline85.neon
@@ -1,0 +1,126 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Certificate.php
+
+		-
+			message: "#^Binary operation \"\\*\" between 40 and string results in an error\\.$#"
+			count: 1
+			path: src/Certificate/Asn1.php
+
+		-
+			message: "#^Parameter \\#2 \\$qIn of static method NFePHP\\\\Common\\\\Certificate\\\\Asn1\\:\\:xBase128\\(\\) expects int, float given\\.$#"
+			count: 1
+			path: src/Certificate/Asn1.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Certificate/PublicKey.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 5
+			path: src/Exception/CertificateException.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 4
+			path: src/Exception/SignerException.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 2
+			path: src/Exception/SoapException.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 2
+			path: src/Exception/ValidatorException.php
+
+		-
+			message: "#^Method NFePHP\\\\Common\\\\Files\\:\\:listContents\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
+			count: 1
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:randomName\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:uid\\(\\) should return string but returns int\\.$#"
+			count: 1
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:uid\\(\\) should return string but returns int\\|false\\.$#"
+			count: 1
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Parameter \\#8 \\$soapheader \\(null\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:send\\(\\) should be compatible with parameter \\$soapheader \\(SoapHeader\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapInterface\\:\\:send\\(\\)$#"
+			count: 1
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Property NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:\\$filesystem \\(NFePHP\\\\Common\\\\Files\\) in empty\\(\\) is not falsy\\.$#"
+			count: 2
+			path: src/Soap/SoapBase.php
+
+		-
+			message: "#^Parameter \\#5 \\$oneWay \\(int\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapClientExtended\\:\\:__doRequest\\(\\) should be compatible with parameter \\$oneWay \\(bool\\) of method SoapClient\\:\\:__doRequest\\(\\)$#"
+			count: 1
+			path: src/Soap/SoapClientExtended.php
+
+		-
+			message: "#^Parameter \\#5 \\$oneWay of method SoapClient\\:\\:__doRequest\\(\\) expects bool, int given\\.$#"
+			count: 1
+			path: src/Soap/SoapClientExtended.php
+
+		-
+			message: "#^Parameter \\#8 \\$soapheader \\(SoapHeader\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapCurl\\:\\:send\\(\\) should be compatible with parameter \\$soapheader \\(null\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:send\\(\\)$#"
+			count: 1
+			path: src/Soap/SoapCurl.php
+
+		-
+			message: "#^Parameter \\#8 \\$soapheader \\(null\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapFake\\:\\:send\\(\\) should be compatible with parameter \\$soapheader \\(SoapHeader\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapInterface\\:\\:send\\(\\)$#"
+			count: 1
+			path: src/Soap/SoapFake.php
+
+		-
+			message: "#^Parameter \\#8 \\$soapheader \\(SoapHeader\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapNative\\:\\:send\\(\\) should be compatible with parameter \\$soapheader \\(null\\) of method NFePHP\\\\Common\\\\Soap\\\\SoapBase\\:\\:send\\(\\)$#"
+			count: 1
+			path: src/Soap/SoapNative.php
+
+		-
+			message: "#^Static method NFePHP\\\\Common\\\\Exception\\\\SoapException\\:\\:soapFault\\(\\) invoked with 1 parameter, 2 required\\.$#"
+			count: 4
+			path: src/Soap/SoapNative.php
+
+		-
+			message: "#^Access to an undefined property NFePHP\\\\Common\\\\Tags\\\\MakeBase\\:\\:\\$emit\\.$#"
+			count: 1
+			path: src/Tags/MakeBase.php
+
+		-
+			message: "#^Access to an undefined property NFePHP\\\\Common\\\\Tags\\\\MakeBase\\:\\:\\$ide\\.$#"
+			count: 9
+			path: src/Tags/MakeBase.php
+
+		-
+			message: "#^Access to an undefined property NFePHP\\\\Common\\\\Tags\\\\MakeBase\\:\\:\\$infnfe\\.$#"
+			count: 2
+			path: src/Tags/MakeBase.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method NFePHP\\\\Common\\\\Tags\\\\MakeBase\\:\\:createProperty\\(\\) expects NFePHP\\\\Common\\\\Tags\\\\TagInterface, array given\\.$#"
+			count: 1
+			path: src/Tags/MakeBase.php
+
+		-
+			message: "#^Undefined variable\\: \\$infId$#"
+			count: 1
+			path: src/Tags/MakeBase.php

--- a/phpstan85.neon
+++ b/phpstan85.neon
@@ -1,0 +1,6 @@
+includes:
+    - phpstan-baseline85.neon
+
+parameters:
+    level: 5
+    treatPhpDocTypesAsCertain: false

--- a/src/Certificate/PublicKey.php
+++ b/src/Certificate/PublicKey.php
@@ -114,8 +114,11 @@ CONTENT;
             $txt = explode("\n", $authority);
             $this->caurl = $this->between($txt[0], 'http', ['.p7b', '.p7c']);
         }
-        $this->validFrom = \DateTime::createFromFormat('ymdHis\Z', $detail['validFrom']);
-        $this->validTo = \DateTime::createFromFormat('ymdHis\Z', $detail['validTo']);
+        // openssl_x509_parse retorna validFrom/validTo em UTC (sufixo "Z" = Zulu).
+        // Sem o DateTimeZone explícito, createFromFormat usa a tz default do PHP, deturpando o valor absoluto.
+        $utc = new \DateTimeZone('UTC');
+        $this->validFrom = \DateTime::createFromFormat('ymdHis\Z', $detail['validFrom'], $utc);
+        $this->validTo = \DateTime::createFromFormat('ymdHis\Z', $detail['validTo'], $utc);
         if (isset($detail['name'])) {
             $arrayName = explode("/", $detail["name"]);
             $arrayName = array_reverse($arrayName);

--- a/tests/Certificate/CertificateTest.php
+++ b/tests/Certificate/CertificateTest.php
@@ -18,8 +18,9 @@ class CertificateTest extends \PHPUnit\Framework\TestCase
     {
         $certificate = Certificate::readPfx(file_get_contents(__DIR__ . self::TEST_PFX_FILE), 'associacao');
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
-        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
-        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->getValidTo());
+        $utc = new \DateTimeZone('UTC');
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03', $utc), $certificate->getValidFrom());
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03', $utc), $certificate->getValidTo());
         $this->assertTrue($certificate->isExpired());
         $dataSigned = $certificate->sign('nfe');
         $this->assertTrue($certificate->verify('nfe', $dataSigned));
@@ -34,8 +35,9 @@ class CertificateTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertInstanceOf(Certificate::class, $certificate);
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $certificate->getCompanyName());
-        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $certificate->getValidFrom());
-        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $certificate->getValidTo());
+        $utc = new \DateTimeZone('UTC');
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03', $utc), $certificate->getValidFrom());
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03', $utc), $certificate->getValidTo());
         $this->assertTrue($certificate->isExpired());
         $dataSigned = $certificate->sign('nfe');
         $this->assertTrue($certificate->verify('nfe', $dataSigned));

--- a/tests/Certificate/CertificateTest.php
+++ b/tests/Certificate/CertificateTest.php
@@ -43,6 +43,62 @@ class CertificateTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($certificate->verify('nfe', $dataSigned));
     }
 
+    /**
+     * Garante que getValidFrom()/getValidTo() devolvem o MESMO instante absoluto
+     * gravado no PFX, independentemente do timezone default do PHP.
+     *
+     * O arquivo PFX guarda as datas em UTC ("...Z"). O openssl_x509_parse expõe esse
+     * instante via validFrom_time_t/validTo_time_t (epoch UTC), que é a fonte de verdade.
+     * Antes da correção, createFromFormat ignorava o "Z" e usava a tz default do PHP,
+     * fazendo o instante absoluto variar conforme o servidor.
+     */
+    public function testGetValidFromAndValidToReturnSameInstantAsPfxRegardlessOfDefaultTimezone()
+    {
+        $pfxContent = file_get_contents(__DIR__ . self::TEST_PFX_FILE);
+
+        // Fonte de verdade: lê direto do PFX via openssl.
+        openssl_pkcs12_read($pfxContent, $certs, 'associacao');
+        $detail = openssl_x509_parse($certs['cert']);
+
+        // Sanity check: o PFX de teste declara estas datas em UTC.
+        $this->assertSame('090522170703Z', $detail['validFrom']);
+        $this->assertSame('101002170703Z', $detail['validTo']);
+        $this->assertSame(1243012023, $detail['validFrom_time_t']); // 2009-05-22 17:07:03 UTC
+        $this->assertSame(1286039223, $detail['validTo_time_t']);   // 2010-10-02 17:07:03 UTC
+
+        $originalTz = date_default_timezone_get();
+        try {
+            // Simula um servidor em São Paulo (UTC-3) — onde o bug aparecia.
+            date_default_timezone_set('America/Sao_Paulo');
+
+            $certificate = Certificate::readPfx($pfxContent, 'associacao');
+
+            // O instante absoluto retornado deve bater com o epoch do PFX.
+            $this->assertSame(
+                $detail['validFrom_time_t'],
+                $certificate->getValidFrom()->getTimestamp(),
+                'getValidFrom() deve devolver o mesmo instante absoluto gravado no PFX'
+            );
+            $this->assertSame(
+                $detail['validTo_time_t'],
+                $certificate->getValidTo()->getTimestamp(),
+                'getValidTo() deve devolver o mesmo instante absoluto gravado no PFX'
+            );
+
+            // E, em UTC, deve formatar exatamente como o "Z" do PFX.
+            $this->assertSame(
+                '2009-05-22 17:07:03',
+                $certificate->getValidFrom()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s')
+            );
+            $this->assertSame(
+                '2010-10-02 17:07:03',
+                $certificate->getValidTo()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s')
+            );
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
     public function testShouldGetExceptionWhenLoadPfxCertificate()
     {
         $this->expectException(\NFePHP\Common\Exception\CertificateException::class);

--- a/tests/Certificate/PublicKeyTest.php
+++ b/tests/Certificate/PublicKeyTest.php
@@ -23,8 +23,9 @@ class PublicKeyTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertInstanceOf(VerificationInterface::class, $this->key);
         $this->assertEquals('NFe - Associacao NF-e:99999090910270', $this->key->commonName);
-        $this->assertEquals(new \DateTime('2009-05-22 17:07:03'), $this->key->validFrom);
-        $this->assertEquals(new \DateTime('2010-10-02 17:07:03'), $this->key->validTo);
+        $utc = new \DateTimeZone('UTC');
+        $this->assertEquals(new \DateTime('2009-05-22 17:07:03', $utc), $this->key->validFrom);
+        $this->assertEquals(new \DateTime('2010-10-02 17:07:03', $utc), $this->key->validTo);
         $this->assertTrue($this->key->isExpired());
     }
 


### PR DESCRIPTION
openssl_x509_parse retorna as datas em UTC (sufixo Z). Sem o DateTimeZone explícito, createFromFormat usa a tz default do PHP e deturpa o valor absoluto, fazendo com que datas fiquem 3 h adiantadas em ambientes com tz America/Sao_Paulo.